### PR TITLE
Remove redundant H0/H0e article tags

### DIFF
--- a/articles/roco/70035.json
+++ b/articles/roco/70035.json
@@ -26,9 +26,7 @@
     "lokomotive",
     "dampflokomotive"
   ],
-  "tags": [
-    "H0"
-  ],
+  "tags": [],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/70035-dampflokomotive-t3-kpev.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/roco/70045.json
+++ b/articles/roco/70045.json
@@ -26,9 +26,7 @@
     "lokomotive",
     "dampflokomotive"
   ],
-  "tags": [
-    "H0"
-  ],
+  "tags": [],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/70045-dampflokomotive-br-8970%e2%80%9375-dr.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/roco/70077.json
+++ b/articles/roco/70077.json
@@ -26,9 +26,7 @@
     "lokomotive",
     "dampflokomotive"
   ],
-  "tags": [
-    "H0"
-  ],
+  "tags": [],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/70077-dampflokomotive-7714-obb.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/roco/70078.json
+++ b/articles/roco/70078.json
@@ -26,9 +26,7 @@
     "lokomotive",
     "dampflokomotive"
   ],
-  "tags": [
-    "H0"
-  ],
+  "tags": [],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/70078-dampflokomotive-7714-obb.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/roco/70321.json
+++ b/articles/roco/70321.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/70321-elektrolokomotive-193-718-4-mrce.html",

--- a/articles/roco/70322.json
+++ b/articles/roco/70322.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/70322-elektrolokomotive-193-718-4-mrce.html",

--- a/articles/roco/7100032.json
+++ b/articles/roco/7100032.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100032-dampflokomotive-86-1563-5-dr.html",

--- a/articles/roco/7100033.json
+++ b/articles/roco/7100033.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100033-dampflokomotive-477-008-csd.html",

--- a/articles/roco/7100036.json
+++ b/articles/roco/7100036.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/home-neuheiten/7100036-dampflokomotive-gattung-ptl-22-kbaystsb.html",

--- a/articles/roco/7100037.json
+++ b/articles/roco/7100037.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100037-dampflokomotive-gattung-pt-23-kbaystsb.html",

--- a/articles/roco/7100038.json
+++ b/articles/roco/7100038.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100038-dampflokomotive-150y16-sncf.html",

--- a/articles/roco/7100039.json
+++ b/articles/roco/7100039.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100039-dampflokomotive-50-2146-4-dr.html",

--- a/articles/roco/7100041.json
+++ b/articles/roco/7100041.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100041-dampflokomotive-1108-kpev.html",

--- a/articles/roco/7100043.json
+++ b/articles/roco/7100043.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100043-dampflokomotive-39-1052-8-dr.html",

--- a/articles/roco/7100044.json
+++ b/articles/roco/7100044.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100044-dampflokomotive-39-237-db.html",

--- a/articles/roco/7100045.json
+++ b/articles/roco/7100045.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100045-dampflokomotive-38-2566-8-dr.html",

--- a/articles/roco/7100046.json
+++ b/articles/roco/7100046.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100046-dampflokomotive-50-1751-db.html",

--- a/articles/roco/7100047.json
+++ b/articles/roco/7100047.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100047-dampflokomotive-rh-109-sudbahn.html",

--- a/articles/roco/7100048.json
+++ b/articles/roco/7100048.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/home-neuheiten/7100048-dampflokomotive-8513-kkstb.html",

--- a/articles/roco/7100049.json
+++ b/articles/roco/7100049.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100049-dampflokomotive-5605-cfl.html",

--- a/articles/roco/7100050.json
+++ b/articles/roco/7100050.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100050-dampflokomotive-ok1-37-pkp.html",

--- a/articles/roco/7100051.json
+++ b/articles/roco/7100051.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100051-dampflokomotive-31021-golsdorf-edition-kkstb.html",

--- a/articles/roco/7110032.json
+++ b/articles/roco/7110032.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110032-dampflokomotive-86-1563-5-dr.html",

--- a/articles/roco/7110036.json
+++ b/articles/roco/7110036.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110036-dampflokomotive-gattung-ptl-22-kbaystsb.html",

--- a/articles/roco/7110037.json
+++ b/articles/roco/7110037.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110037-dampflokomotive-gattung-pt-23-kbaystsb.html",

--- a/articles/roco/7110038.json
+++ b/articles/roco/7110038.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110038-dampflokomotive-150y16-sncf.html",

--- a/articles/roco/7110039.json
+++ b/articles/roco/7110039.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110039-dampflokomotive-50-2146-4-dr.html",

--- a/articles/roco/7110041.json
+++ b/articles/roco/7110041.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110041-dampflokomotive-1108-kpev.html",

--- a/articles/roco/7110043.json
+++ b/articles/roco/7110043.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110043-dampflokomotive-39-1052-8-dr.html",

--- a/articles/roco/7110044.json
+++ b/articles/roco/7110044.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110044-dampflokomotive-39-237-db.html",

--- a/articles/roco/7110045.json
+++ b/articles/roco/7110045.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110045-dampflokomotive-38-2566-8-dr.html",

--- a/articles/roco/7110046.json
+++ b/articles/roco/7110046.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110046-dampflokomotive-50-1751-db.html",

--- a/articles/roco/7110047.json
+++ b/articles/roco/7110047.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110047-dampflokomotive-rh-109-sudbahn.html",

--- a/articles/roco/7110050.json
+++ b/articles/roco/7110050.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110050-dampflokomotive-ok1-37-pkp.html",

--- a/articles/roco/7110051.json
+++ b/articles/roco/7110051.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110051-dampflokomotive-31021-golsdorf-edition-kkstb.html",

--- a/articles/roco/7120032.json
+++ b/articles/roco/7120032.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120032-dampflokomotive-86-1563-5-dr.html",

--- a/articles/roco/7120033.json
+++ b/articles/roco/7120033.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120033-dampflokomotive-477-008-csd.html",

--- a/articles/roco/7120038.json
+++ b/articles/roco/7120038.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120038-dampflokomotive-150y16-sncf.html",

--- a/articles/roco/7120039.json
+++ b/articles/roco/7120039.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120039-dampflokomotive-50-2146-4-dr.html",

--- a/articles/roco/7120041.json
+++ b/articles/roco/7120041.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120041-dampflokomotive-1108-kpev.html",

--- a/articles/roco/7120044.json
+++ b/articles/roco/7120044.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120044-dampflokomotive-39-237-db.html",

--- a/articles/roco/7120045.json
+++ b/articles/roco/7120045.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120045-dampflokomotive-38-2566-8-dr.html",

--- a/articles/roco/7120046.json
+++ b/articles/roco/7120046.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120046-dampflokomotive-50-1751-db.html",

--- a/articles/roco/7120047.json
+++ b/articles/roco/7120047.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120047-dampflokomotive-rh-109-sudbahn.html",

--- a/articles/roco/7120051.json
+++ b/articles/roco/7120051.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120051-dampflokomotive-31021-golsdorf-edition-kkstb.html",

--- a/articles/roco/71395.json
+++ b/articles/roco/71395.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71395-dampflokomotive-38-3713-drg.html",

--- a/articles/roco/71396.json
+++ b/articles/roco/71396.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71396-dampflokomotive-38-3713-drg.html",

--- a/articles/roco/7300021.json
+++ b/articles/roco/7300021.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300021-diesellokomotive-742-156-3-cd.html",

--- a/articles/roco/7300022.json
+++ b/articles/roco/7300022.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300022-diesellokomotive-t-466-2114-csd.html",

--- a/articles/roco/7300068.json
+++ b/articles/roco/7300068.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300068-diesellokomotive-217-003-3-db.html",

--- a/articles/roco/7300082.json
+++ b/articles/roco/7300082.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300082-diesellokomotive-754-083-4-zssk.html",

--- a/articles/roco/7300083.json
+++ b/articles/roco/7300083.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300083-diesellokomotive-nr-1-dbp.html",

--- a/articles/roco/7300084.json
+++ b/articles/roco/7300084.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300084-diesellokomotive-ld61-fvs.html",

--- a/articles/roco/7300085.json
+++ b/articles/roco/7300085.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300085-diesellokomotive-118-158-5-dr.html",

--- a/articles/roco/7300086.json
+++ b/articles/roco/7300086.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300086-diesellokomotive-m62-901-gysev.html",

--- a/articles/roco/7300087.json
+++ b/articles/roco/7300087.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300087-diesellokomotive-2016-015-7-obb.html",

--- a/articles/roco/7300088.json
+++ b/articles/roco/7300088.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300088-diesellokomotive-753-211-2-cd.html",

--- a/articles/roco/7300089.json
+++ b/articles/roco/7300089.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300089-diesellokomotive-754-047-9-cd.html",

--- a/articles/roco/7300090.json
+++ b/articles/roco/7300090.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300090-diesellokomotive-t-478-2079-csd.html",

--- a/articles/roco/7300092.json
+++ b/articles/roco/7300092.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300092-diesellokomotive-2143-047-5-obb.html",

--- a/articles/roco/7300093.json
+++ b/articles/roco/7300093.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300093-diesellokomotive-2143-062-5-regiobahn.html",

--- a/articles/roco/7300094.json
+++ b/articles/roco/7300094.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300094-diesellokomotive-234-399-4-db-ag.html",

--- a/articles/roco/7300096.json
+++ b/articles/roco/7300096.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300096-diesellokomotive-120-144-1-dr.html",

--- a/articles/roco/7300097.json
+++ b/articles/roco/7300097.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300097-diesellokomotive-cc-72052-sncf.html",

--- a/articles/roco/7300098.json
+++ b/articles/roco/7300098.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300098-diesellokomotive-211-043-5-db.html",

--- a/articles/roco/7300103.json
+++ b/articles/roco/7300103.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300103-diesellokomotive-232-592-6-ebs.html",

--- a/articles/roco/7300104.json
+++ b/articles/roco/7300104.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300104-diesellokomotive-22-warsteiner-wle.html",

--- a/articles/roco/7300105.json
+++ b/articles/roco/7300105.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300105-diesellokomotive-232-550-4-db-ag.html",

--- a/articles/roco/7300106.json
+++ b/articles/roco/7300106.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300106-diesellokomotive-290-276-5-db.html",

--- a/articles/roco/7300107.json
+++ b/articles/roco/7300107.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300107-diesellokomotive-br-110-dr.html",

--- a/articles/roco/7310021.json
+++ b/articles/roco/7310021.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310021-diesellokomotive-742-156-3-cd.html",

--- a/articles/roco/7310022.json
+++ b/articles/roco/7310022.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310022-diesellokomotive-t-466-2114-csd.html",

--- a/articles/roco/7310024.json
+++ b/articles/roco/7310024.json
@@ -26,8 +26,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310024-diesellokomotive-sik-volkerrail.html",

--- a/articles/roco/7310068.json
+++ b/articles/roco/7310068.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310068-diesellokomotive-217-003-3-db.html",

--- a/articles/roco/7310082.json
+++ b/articles/roco/7310082.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310082-diesellokomotive-754-083-4-zssk.html",

--- a/articles/roco/7310083.json
+++ b/articles/roco/7310083.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310083-diesellokomotive-nr-1-dbp.html",

--- a/articles/roco/7310085.json
+++ b/articles/roco/7310085.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310085-diesellokomotive-118-158-5-dr.html",

--- a/articles/roco/7310086.json
+++ b/articles/roco/7310086.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310086-diesellokomotive-m62-901-gysev.html",

--- a/articles/roco/7310087.json
+++ b/articles/roco/7310087.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310087-diesellokomotive-2016-015-7-obb.html",

--- a/articles/roco/7310088.json
+++ b/articles/roco/7310088.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310088-diesellokomotive-753-211-2-cd.html",

--- a/articles/roco/7310089.json
+++ b/articles/roco/7310089.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310089-diesellokomotive-754-047-9-cd.html",

--- a/articles/roco/7310090.json
+++ b/articles/roco/7310090.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310090-diesellokomotive-t-478-2079-csd.html",

--- a/articles/roco/7310092.json
+++ b/articles/roco/7310092.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310092-diesellokomotive-2143-047-5-obb.html",

--- a/articles/roco/7310094.json
+++ b/articles/roco/7310094.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310094-diesellokomotive-234-399-4-db-ag.html",

--- a/articles/roco/7310095.json
+++ b/articles/roco/7310095.json
@@ -26,8 +26,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310095-diesellokomotive-y-8208-sncf.html",

--- a/articles/roco/7310096.json
+++ b/articles/roco/7310096.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310096-diesellokomotive-120-144-1-dr.html",

--- a/articles/roco/7310097.json
+++ b/articles/roco/7310097.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310097-diesellokomotive-cc-72052-sncf.html",

--- a/articles/roco/7310098.json
+++ b/articles/roco/7310098.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310098-diesellokomotive-211-043-5-db.html",

--- a/articles/roco/7310103.json
+++ b/articles/roco/7310103.json
@@ -26,8 +26,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310103-diesellokomotive-232-592-6-ebs.html",

--- a/articles/roco/7310104.json
+++ b/articles/roco/7310104.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310104-diesellokomotive-22-warsteiner-wle.html",

--- a/articles/roco/7310105.json
+++ b/articles/roco/7310105.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310105-diesellokomotive-232-550-4-db-ag.html",

--- a/articles/roco/7310106.json
+++ b/articles/roco/7310106.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310106-diesellokomotive-290-276-5-db.html",

--- a/articles/roco/7310107.json
+++ b/articles/roco/7310107.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310107-diesellokomotive-br-110-dr.html",

--- a/articles/roco/7310108.json
+++ b/articles/roco/7310108.json
@@ -26,8 +26,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310108-diesellokomotive-335-108-7-db.html",

--- a/articles/roco/7320024.json
+++ b/articles/roco/7320024.json
@@ -26,8 +26,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320024-diesellokomotive-sik-volkerrail.html",

--- a/articles/roco/7320068.json
+++ b/articles/roco/7320068.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320068-diesellokomotive-217-003-3-db.html",

--- a/articles/roco/7320083.json
+++ b/articles/roco/7320083.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320083-diesellokomotive-nr-1-dbp.html",

--- a/articles/roco/7320085.json
+++ b/articles/roco/7320085.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320085-diesellokomotive-118-158-5-dr.html",

--- a/articles/roco/7320087.json
+++ b/articles/roco/7320087.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320087-diesellokomotive-2016-015-7-obb.html",

--- a/articles/roco/7320088.json
+++ b/articles/roco/7320088.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320088-diesellokomotive-753-211-2-cd.html",

--- a/articles/roco/7320092.json
+++ b/articles/roco/7320092.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320092-diesellokomotive-2143-047-5-obb.html",

--- a/articles/roco/7320094.json
+++ b/articles/roco/7320094.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320094-diesellokomotive-234-399-4-db-ag.html",

--- a/articles/roco/7320095.json
+++ b/articles/roco/7320095.json
@@ -26,8 +26,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320095-diesellokomotive-y-8208-sncf.html",

--- a/articles/roco/7320096.json
+++ b/articles/roco/7320096.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320096-diesellokomotive-120-144-1-dr.html",

--- a/articles/roco/7320097.json
+++ b/articles/roco/7320097.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320097-diesellokomotive-cc-72052-sncf.html",

--- a/articles/roco/7320098.json
+++ b/articles/roco/7320098.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320098-diesellokomotive-211-043-5-db.html",

--- a/articles/roco/7320103.json
+++ b/articles/roco/7320103.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320103-diesellokomotive-232-592-6-ebs.html",

--- a/articles/roco/7320104.json
+++ b/articles/roco/7320104.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320104-diesellokomotive-22-warsteiner-wle.html",

--- a/articles/roco/7320105.json
+++ b/articles/roco/7320105.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320105-diesellokomotive-232-550-4-db-ag.html",

--- a/articles/roco/7320106.json
+++ b/articles/roco/7320106.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320106-diesellokomotive-290-276-5-db.html",

--- a/articles/roco/7320107.json
+++ b/articles/roco/7320107.json
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320107-diesellokomotive-br-110-dr.html",

--- a/articles/roco/7500065.json
+++ b/articles/roco/7500065.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500065-elektrolokomotive-193-459-5-deutschlandpiercer-sbb-cargo-international.html",

--- a/articles/roco/7500073.json
+++ b/articles/roco/7500073.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500073-elektrolokomotive-193-452-0-schweizpiercer-sbb-cargo-international.html",

--- a/articles/roco/7500100.json
+++ b/articles/roco/7500100.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500100-elektrolokomotive-193-958-6-lte.html",

--- a/articles/roco/7500122.json
+++ b/articles/roco/7500122.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500122-elektrolokomotive-eu05-25-pkp.html",

--- a/articles/roco/7500135.json
+++ b/articles/roco/7500135.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500135-elektrolokomotive-121-046-7-cd.html",

--- a/articles/roco/7500146.json
+++ b/articles/roco/7500146.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500146-elektrolokomotive-bb-15060-sncf.html",

--- a/articles/roco/7500148.json
+++ b/articles/roco/7500148.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500148-elektrolokomotive-e-44-509-db.html",

--- a/articles/roco/7500157.json
+++ b/articles/roco/7500157.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500157-elektrolokomotive-103-233-3-db-ag.html",

--- a/articles/roco/7500158.json
+++ b/articles/roco/7500158.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500158-elektrolokomotive-112-101-1-db-ag.html",

--- a/articles/roco/7500159.json
+++ b/articles/roco/7500159.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500159-elektrolokomotive-re-44-172-bls.html",

--- a/articles/roco/7500160.json
+++ b/articles/roco/7500160.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500160-elektrolokomotive-re-66-11646-sbb-cargo.html",

--- a/articles/roco/7500161.json
+++ b/articles/roco/7500161.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500161-elektrolokomotive-186-251-5-railpool.html",

--- a/articles/roco/7500164.json
+++ b/articles/roco/7500164.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500164-elektrolokomotive-141-152-9-db.html",

--- a/articles/roco/7500165.json
+++ b/articles/roco/7500165.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500165-elektrolokomotive-1750-rail-force-one.html",

--- a/articles/roco/7500167.json
+++ b/articles/roco/7500167.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500167-elektrolokomotive-482-038-0-nrfab.html",

--- a/articles/roco/7500168.json
+++ b/articles/roco/7500168.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500168-elektrolokomotive-bb-26005-sncf.html",

--- a/articles/roco/7500170.json
+++ b/articles/roco/7500170.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500170-elektrolokomotive-re-44-iii-43-sob.html",

--- a/articles/roco/7500172.json
+++ b/articles/roco/7500172.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500172-elektrolokomotive-re-465-008-1-bls.html",

--- a/articles/roco/7500173.json
+++ b/articles/roco/7500173.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500173-elektrolokomotive-re-436-113-5-crossrail.html",

--- a/articles/roco/7500174.json
+++ b/articles/roco/7500174.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500174-elektrolokomotive-7193-306-6-tx-logistik.html",

--- a/articles/roco/7500175.json
+++ b/articles/roco/7500175.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500175-elektrolokomotive-rem-476-457-7-railcare.html",

--- a/articles/roco/7500176.json
+++ b/articles/roco/7500176.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500176-elektrolokomotive-189-905-3-rtc.html",

--- a/articles/roco/7500177.json
+++ b/articles/roco/7500177.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500177-elektrolokomotive-145-074-1-db-ag.html",

--- a/articles/roco/7500178.json
+++ b/articles/roco/7500178.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500178-elektrolokomotive-145-070-9-rbh.html",

--- a/articles/roco/7500179.json
+++ b/articles/roco/7500179.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500179-elektrolokomotive-da-917-sj.html",

--- a/articles/roco/7500181.json
+++ b/articles/roco/7500181.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500181-elektrolokomotive-e-4691018-csd.html",

--- a/articles/roco/7500182.json
+++ b/articles/roco/7500182.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500182-elektrolokomotive-1216-016-6-railjet-obb.html",

--- a/articles/roco/7500183.json
+++ b/articles/roco/7500183.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500183-elektrolokomotive-rc-4-1173-sj.html",

--- a/articles/roco/7500184.json
+++ b/articles/roco/7500184.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500184-elektrolokomotive-182-573-6-mav-start.html",

--- a/articles/roco/7500185.json
+++ b/articles/roco/7500185.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500185-elektrolokomotive-7193-101-1-alpha-trainsrheincargo.html",

--- a/articles/roco/7500186.json
+++ b/articles/roco/7500186.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500186-elektrolokomotive-193-568-3-cd.html",

--- a/articles/roco/7500188.json
+++ b/articles/roco/7500188.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500188-elektrolokomotive-189-909-5-beacon-rail.html",

--- a/articles/roco/7500189.json
+++ b/articles/roco/7500189.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500189-elektrolokomotive-263-010-1-zssk.html",

--- a/articles/roco/7500190.json
+++ b/articles/roco/7500190.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500190-elektrolokomotive-140-423-5-db-ag.html",

--- a/articles/roco/7500191.json
+++ b/articles/roco/7500191.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500191-elektrolokomotive-193-996-3-rtc.html",

--- a/articles/roco/7500192.json
+++ b/articles/roco/7500192.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500192-elektrolokomotive-193-934-7-ns.html",

--- a/articles/roco/7500194.json
+++ b/articles/roco/7500194.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500194-elektrolokomotive-193-128-6-railpool.html",

--- a/articles/roco/7500195.json
+++ b/articles/roco/7500195.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500195-elektrolokomotive-186-945-2-lte.html",

--- a/articles/roco/7500196.json
+++ b/articles/roco/7500196.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500196-elektrolokomotive-370-094-2-adriatic-express-pkp-ic.html",

--- a/articles/roco/7500197.json
+++ b/articles/roco/7500197.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500197-elektrolokomotive-1616-db-ag.html",

--- a/articles/roco/7500198.json
+++ b/articles/roco/7500198.json
@@ -26,8 +26,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500198-elektrolokomotive-e-44-015-drb.html",

--- a/articles/roco/7500206.json
+++ b/articles/roco/7500206.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500206-elektrolokomotive-189-095-3-db-ag.html",

--- a/articles/roco/7500207.json
+++ b/articles/roco/7500207.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500207-elektrolokomotive-189-031-8-db-ag.html",

--- a/articles/roco/7500210.json
+++ b/articles/roco/7500210.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500210-elektrolokomotive-rc-4-1166-nrfab.html",

--- a/articles/roco/7500211.json
+++ b/articles/roco/7500211.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500211-elektrolokomotive-4620-052-4-nrfab.html",

--- a/articles/roco/7500218.json
+++ b/articles/roco/7500218.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500218-elektrolokomotive-185-325-5-ebstrustrail.html",

--- a/articles/roco/7500222.json
+++ b/articles/roco/7500222.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500222-elektrolokomotive-re-44-ii-11143-sbb.html",

--- a/articles/roco/7500224.json
+++ b/articles/roco/7500224.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500224-elektrolokomotive-101-091-7-db-ag.html",

--- a/articles/roco/7510073.json
+++ b/articles/roco/7510073.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510073-elektrolokomotive-193-452-0-schweizpiercer-sbb-cargo-international.html",

--- a/articles/roco/7510100.json
+++ b/articles/roco/7510100.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510100-elektrolokomotive-193-958-6-lte.html",

--- a/articles/roco/7510122.json
+++ b/articles/roco/7510122.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510122-elektrolokomotive-eu05-25-pkp.html",

--- a/articles/roco/7510135.json
+++ b/articles/roco/7510135.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510135-elektrolokomotive-121-046-7-cd.html",

--- a/articles/roco/7510146.json
+++ b/articles/roco/7510146.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510146-elektrolokomotive-bb-15060-sncf.html",

--- a/articles/roco/7510157.json
+++ b/articles/roco/7510157.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510157-elektrolokomotive-103-233-3-db-ag.html",

--- a/articles/roco/7510158.json
+++ b/articles/roco/7510158.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510158-elektrolokomotive-112-101-1-db-ag.html",

--- a/articles/roco/7510159.json
+++ b/articles/roco/7510159.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510159-elektrolokomotive-re-44-172-bls.html",

--- a/articles/roco/7510160.json
+++ b/articles/roco/7510160.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510160-elektrolokomotive-re-66-11646-sbb-cargo.html",

--- a/articles/roco/7510161.json
+++ b/articles/roco/7510161.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510161-elektrolokomotive-186-251-5-railpool.html",

--- a/articles/roco/7510163.json
+++ b/articles/roco/7510163.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510163-elektrolokomotive-rh-1144-valousek-edition-obb.html",

--- a/articles/roco/7510164.json
+++ b/articles/roco/7510164.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510164-elektrolokomotive-141-152-9-db.html",

--- a/articles/roco/7510165.json
+++ b/articles/roco/7510165.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510165-elektrolokomotive-1750-rail-force-one.html",

--- a/articles/roco/7510166.json
+++ b/articles/roco/7510166.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510166-elektrolokomotive-186-119-1-sncb.html",

--- a/articles/roco/7510167.json
+++ b/articles/roco/7510167.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510167-elektrolokomotive-482-038-7-nrfab.html",

--- a/articles/roco/7510168.json
+++ b/articles/roco/7510168.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510168-elektrolokomotive-bb-26005-sncf.html",

--- a/articles/roco/7510170.json
+++ b/articles/roco/7510170.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510170-elektrolokomotive-re-44-iii-43-sob.html",

--- a/articles/roco/7510172.json
+++ b/articles/roco/7510172.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510172-elektrolokomotive-re-465-008-1-bls.html",

--- a/articles/roco/7510173.json
+++ b/articles/roco/7510173.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510173-elektrolokomotive-re-436-113-5-crossrail.html",

--- a/articles/roco/7510174.json
+++ b/articles/roco/7510174.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510174-elektrolokomotive-7193-306-6-tx-logistik.html",

--- a/articles/roco/7510175.json
+++ b/articles/roco/7510175.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510175-elektrolokomotive-rem-476-457-7-railcare.html",

--- a/articles/roco/7510176.json
+++ b/articles/roco/7510176.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510176-elektrolokomotive-189-905-3-rtc.html",

--- a/articles/roco/7510177.json
+++ b/articles/roco/7510177.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510177-elektrolokomotive-145-074-1-db-ag.html",

--- a/articles/roco/7510178.json
+++ b/articles/roco/7510178.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510178-elektrolokomotive-145-070-9-rbh.html",

--- a/articles/roco/7510179.json
+++ b/articles/roco/7510179.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510179-elektrolokomotive-da-917-sj.html",

--- a/articles/roco/7510181.json
+++ b/articles/roco/7510181.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510181-elektrolokomotive-e-4691018-csd.html",

--- a/articles/roco/7510182.json
+++ b/articles/roco/7510182.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510182-elektrolokomotive-1216-016-6-railjet-obb.html",

--- a/articles/roco/7510183.json
+++ b/articles/roco/7510183.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510183-elektrolokomotive-rc-4-1173-sj.html",

--- a/articles/roco/7510185.json
+++ b/articles/roco/7510185.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510185-elektrolokomotive-7193-101-1-alpha-trainsrheincargo.html",

--- a/articles/roco/7510186.json
+++ b/articles/roco/7510186.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510186-elektrolokomotive-193-568-3-cd.html",

--- a/articles/roco/7510188.json
+++ b/articles/roco/7510188.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510188-elektrolokomotive-189-909-5-beacon-rail.html",

--- a/articles/roco/7510189.json
+++ b/articles/roco/7510189.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510189-elektrolokomotive-263-010-1-zssk.html",

--- a/articles/roco/7510190.json
+++ b/articles/roco/7510190.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510190-elektrolokomotive-140-423-5-db-ag.html",

--- a/articles/roco/7510191.json
+++ b/articles/roco/7510191.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510191-elektrolokomotive-193-996-3-rtc.html",

--- a/articles/roco/7510192.json
+++ b/articles/roco/7510192.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510192-elektrolokomotive-193-934-7-ns.html",

--- a/articles/roco/7510196.json
+++ b/articles/roco/7510196.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510196-elektrolokomotive-370-094-2-adriatic-express-pkp-ic.html",

--- a/articles/roco/7510197.json
+++ b/articles/roco/7510197.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510197-elektrolokomotive-1616-db-ag.html",

--- a/articles/roco/7510206.json
+++ b/articles/roco/7510206.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510206-elektrolokomotive-189-095-3-db-ag.html",

--- a/articles/roco/7510207.json
+++ b/articles/roco/7510207.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510207-elektrolokomotive-189-031-8-db-ag.html",

--- a/articles/roco/7510210.json
+++ b/articles/roco/7510210.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510210-elektrolokomotive-rc-4-1166-nrfab.html",

--- a/articles/roco/7510211.json
+++ b/articles/roco/7510211.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510211-elektrolokomotive-4620-052-4-nrfab.html",

--- a/articles/roco/7510212.json
+++ b/articles/roco/7510212.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510212-elektrolokomotive-194-080-8-db.html",

--- a/articles/roco/7510218.json
+++ b/articles/roco/7510218.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510218-elektrolokomotive-185-325-5-ebstrustrail.html",

--- a/articles/roco/7510222.json
+++ b/articles/roco/7510222.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510222-elektrolokomotive-re-44-ii-11143-sbb.html",

--- a/articles/roco/7510224.json
+++ b/articles/roco/7510224.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510224-elektrolokomotive-101-091-7-db-ag.html",

--- a/articles/roco/7520073.json
+++ b/articles/roco/7520073.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520073-elektrolokomotive-193-452-0-schweizpiercer-sbb-cargo-international.html",

--- a/articles/roco/7520100.json
+++ b/articles/roco/7520100.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520100-elektrolokomotive-193-958-6-lte.html",

--- a/articles/roco/7520146.json
+++ b/articles/roco/7520146.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520146-elektrolokomotive-bb-15060-sncf.html",

--- a/articles/roco/7520148.json
+++ b/articles/roco/7520148.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520148-elektrolokomotive-e-44-509-db.html",

--- a/articles/roco/7520157.json
+++ b/articles/roco/7520157.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520157-elektrolokomotive-103-233-3-db-ag.html",

--- a/articles/roco/7520158.json
+++ b/articles/roco/7520158.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520158-elektrolokomotive-112-101-1-db-ag.html",

--- a/articles/roco/7520159.json
+++ b/articles/roco/7520159.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520159-elektrolokomotive-re-44-172-bls.html",

--- a/articles/roco/7520160.json
+++ b/articles/roco/7520160.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520160-elektrolokomotive-re-66-11646-sbb-cargo.html",

--- a/articles/roco/7520161.json
+++ b/articles/roco/7520161.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520161-elektrolokomotive-186-251-5-railpool.html",

--- a/articles/roco/7520163.json
+++ b/articles/roco/7520163.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520163-elektrolokomotive-rh-1144-valousek-edition-obb.html",

--- a/articles/roco/7520164.json
+++ b/articles/roco/7520164.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520164-elektrolokomotive-141-152-9-db.html",

--- a/articles/roco/7520165.json
+++ b/articles/roco/7520165.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520165-elektrolokomotive-1750-rail-force-one.html",

--- a/articles/roco/7520167.json
+++ b/articles/roco/7520167.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520167-elektrolokomotive-482-038-7-nrfab.html",

--- a/articles/roco/7520168.json
+++ b/articles/roco/7520168.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520168-elektrolokomotive-bb-26005-sncf.html",

--- a/articles/roco/7520170.json
+++ b/articles/roco/7520170.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520170-elektrolokomotive-re-44-iii-43-sob.html",

--- a/articles/roco/7520172.json
+++ b/articles/roco/7520172.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520172-elektrolokomotive-re-465-008-1-bls.html",

--- a/articles/roco/7520173.json
+++ b/articles/roco/7520173.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520173-elektrolokomotive-re-436-113-5-crossrail.html",

--- a/articles/roco/7520174.json
+++ b/articles/roco/7520174.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520174-elektrolokomotive-7193-306-6-tx-logistik.html",

--- a/articles/roco/7520175.json
+++ b/articles/roco/7520175.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520175-elektrolokomotive-rem-476-457-7-railcare.html",

--- a/articles/roco/7520176.json
+++ b/articles/roco/7520176.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520176-elektrolokomotive-189-905-3-rtc.html",

--- a/articles/roco/7520177.json
+++ b/articles/roco/7520177.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520177-elektrolokomotive-145-074-1-db-ag.html",

--- a/articles/roco/7520178.json
+++ b/articles/roco/7520178.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520178-elektrolokomotive-145-070-9-rbh.html",

--- a/articles/roco/7520179.json
+++ b/articles/roco/7520179.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520179-elektrolokomotive-da-917-sj.html",

--- a/articles/roco/7520182.json
+++ b/articles/roco/7520182.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520182-elektrolokomotive-1216-016-6-railjet-obb.html",

--- a/articles/roco/7520183.json
+++ b/articles/roco/7520183.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520183-elektrolokomotive-rc-4-1173-sj.html",

--- a/articles/roco/7520185.json
+++ b/articles/roco/7520185.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520185-elektrolokomotive-7193-101-1-alpha-trainsrheincargo.html",

--- a/articles/roco/7520186.json
+++ b/articles/roco/7520186.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520186-elektrolokomotive-193-568-3-cd.html",

--- a/articles/roco/7520188.json
+++ b/articles/roco/7520188.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520188-elektrolokomotive-189-909-5-beacon-rail.html",

--- a/articles/roco/7520190.json
+++ b/articles/roco/7520190.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520190-elektrolokomotive-140-423-5-db-ag.html",

--- a/articles/roco/7520191.json
+++ b/articles/roco/7520191.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520191-elektrolokomotive-193-996-3-rtc.html",

--- a/articles/roco/7520192.json
+++ b/articles/roco/7520192.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520192-elektrolokomotive-193-934-7-ns.html",

--- a/articles/roco/7520194.json
+++ b/articles/roco/7520194.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520194-elektrolokomotive-193-128-6-railpool.html",

--- a/articles/roco/7520196.json
+++ b/articles/roco/7520196.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520196-elektrolokomotive-370-094-2-adriatic-express-pkp-ic.html",

--- a/articles/roco/7520197.json
+++ b/articles/roco/7520197.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520197-elektrolokomotive-1616-db-ag.html",

--- a/articles/roco/7520206.json
+++ b/articles/roco/7520206.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520206-elektrolokomotive-189-095-3-db-ag.html",

--- a/articles/roco/7520207.json
+++ b/articles/roco/7520207.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520207-elektrolokomotive-189-031-8-db-ag.html",

--- a/articles/roco/7520210.json
+++ b/articles/roco/7520210.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520210-elektrolokomotive-rc-4-1166-nrfab.html",

--- a/articles/roco/7520211.json
+++ b/articles/roco/7520211.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520211-elektrolokomotive-4620-052-4-nrfab.html",

--- a/articles/roco/7520218.json
+++ b/articles/roco/7520218.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520218-elektrolokomotive-185-325-5-ebstrustrail.html",

--- a/articles/roco/7520222.json
+++ b/articles/roco/7520222.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520222-elektrolokomotive-re-44-ii-11143-sbb.html",

--- a/articles/roco/7520224.json
+++ b/articles/roco/7520224.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520224-elektrolokomotive-101-091-7-db-ag.html",

--- a/articles/roco/7540007.json
+++ b/articles/roco/7540007.json
@@ -5,7 +5,7 @@
   "articleNumber": "7540007",
   "releaseDate": "Frühling 2026",
   "uvp": {
-    "amount": 239.0,
+    "amount": 239,
     "currency": "EUR"
   },
   "model": {
@@ -27,8 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0e"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7540007-diesellokomotive-209513-obb.html",

--- a/articles/roco/7540008.json
+++ b/articles/roco/7540008.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0e"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7540008-elektrolokomotive-109913-obb.html",

--- a/articles/roco/7550008.json
+++ b/articles/roco/7550008.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0e"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7550008-elektrolokomotive-109913-obb.html",

--- a/articles/roco/7700016.json
+++ b/articles/roco/7700016.json
@@ -28,8 +28,7 @@
     "akkutriebwagen"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7700016-akkutriebwagen-515-537-9-mit-steuerwagen-db.html",

--- a/articles/roco/7700032.json
+++ b/articles/roco/7700032.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7700032-6-tlg-set-elektrotriebzug-flirt-3-brb.html",

--- a/articles/roco/7700033.json
+++ b/articles/roco/7700033.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7700033-5-tlg-set-elektrotriebzug-flirt-3-arverio.html",

--- a/articles/roco/7700036.json
+++ b/articles/roco/7700036.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7700036-5-tlg-set-elektrischer-triebzug-icn-rabde-500-039-8-sbb.html",

--- a/articles/roco/7710016.json
+++ b/articles/roco/7710016.json
@@ -28,8 +28,7 @@
     "akkutriebwagen"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7710016-akkutriebwagen-515-537-9-mit-steuerwagen-db.html",

--- a/articles/roco/7710032.json
+++ b/articles/roco/7710032.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7710032-6-tlg-set-elektrotriebzug-flirt-3-brb.html",

--- a/articles/roco/7710033.json
+++ b/articles/roco/7710033.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7710033-5-tlg-set-elektrotriebzug-flirt-3-arverio.html",

--- a/articles/roco/7710036.json
+++ b/articles/roco/7710036.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7710036-5-tlg-set-elektrischer-triebzug-icn-rabde-500-039-8-sbb.html",

--- a/articles/roco/7720016.json
+++ b/articles/roco/7720016.json
@@ -28,8 +28,7 @@
     "akkutriebwagen"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7720016-akkutriebwagen-515-537-9-mit-steuerwagen-db.html",

--- a/articles/roco/7720032.json
+++ b/articles/roco/7720032.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7720032-6-tlg-set-elektrotriebzug-flirt-3-brb.html",

--- a/articles/roco/7720033.json
+++ b/articles/roco/7720033.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7720033-5-tlg-set-elektrotriebzug-flirt-3-arverio.html",

--- a/articles/roco/7720036.json
+++ b/articles/roco/7720036.json
@@ -27,8 +27,7 @@
     "triebzug"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7720036-5-tlg-set-elektrischer-triebzug-icn-rabde-500-039-8-sbb.html",

--- a/articles/roco/78322.json
+++ b/articles/roco/78322.json
@@ -27,8 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/78322-elektrolokomotive-193-718-4-mrce.html",

--- a/articles/roco/79396.json
+++ b/articles/roco/79396.json
@@ -27,8 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-neuheiten-2026",
-    "H0"
+    "roco-neuheiten-2026"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/79396-dampflokomotive-38-3713-drg.html",

--- a/config/tags/h0.json
+++ b/config/tags/h0.json
@@ -1,6 +1,0 @@
-{
-  "schemaVersion": "1.0.0",
-  "name": "H0",
-  "slug": "H0",
-  "description": "Tag für Modelle im Massstab H0."
-}

--- a/config/tags/h0e.json
+++ b/config/tags/h0e.json
@@ -1,6 +1,0 @@
-{
-  "schemaVersion": "1.0.0",
-  "name": "H0e",
-  "slug": "H0e",
-  "description": "Tag für Modelle im Massstab H0e (Schmalspur)."
-}


### PR DESCRIPTION
Removes scale duplicates from the `tags` array on all articles; scale stays on `model.scale`.

Deletes `config/tags/h0.json` and `config/tags/h0e.json` so validation matches the remaining tag vocabulary. Four articles that only had `H0` now have an empty `tags` array.

After merge, run `npm run build:index` if `artifacts/tags.json` should be refreshed in-repo.

Made with [Cursor](https://cursor.com)