### PR TITLE
Dokumentation: CI-Badges, CH-de, gestrafft

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
 ## Zusammenfassung
 
-Bitte kurz beschreiben, was ergänzt oder korrigiert wurde.
+Kurz beschreiben, was ergänzt oder korrigiert wurde.
 
-## Checklist
+## Checkliste
 
-- [ ] Schema wurde eingehalten.
-- [ ] Pflichtfelder sind ausgefüllt.
-- [ ] Quelle (`source.url`) ist angegeben oder im PR begründet.
-- [ ] Änderungen wurden lokal geprüft (`npm run check`).
-- [ ] CI-Workflow **Validate Data** ist grün.
-- [ ] Daten sind in Deutsch gepflegt, sofern Freitext genutzt wurde.
+- [ ] Schema eingehalten.
+- [ ] Pflichtfelder ausgefüllt.
+- [ ] Quelle (`source.url`) gesetzt oder im PR begründet.
+- [ ] Lokal `npm run check` ausgeführt.
+- [ ] CI **Validate Data** ist grün.
+- [ ] Freitext auf Deutsch, sofern zutreffend.
 
-## Hinweise
+## Hinweis
 
-Wenn AI genutzt wurde, bitte kurz erwähnen, wie die Inhalte verifiziert wurden.
+Bei KI-Unterstützung: kurz erwähnen, wie Inhalte verifiziert wurden.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,53 +5,42 @@ Danke für deinen Beitrag.
 ## Schnellstart
 
 1. Fork erstellen.
-2. Neue Datei unter `articles/{manufacturerSlug}/` anlegen.
+2. Neue Datei unter `articles/{manufacturerSlug}/` anlegen (eine Datei pro Artikel).
 3. Schema aus `contracts/article.schema.json` einhalten.
-4. Lokal prüfen mit `npm ci` und `npm run check` (Node 22 empfohlen).
+4. Lokal: `npm ci`, danach `npm run check` (Node 22 empfohlen).
 5. Pull Request mit kurzer Quellenangabe öffnen.
 
-Nach `npm ci` richtet das **`prepare`**-Skript **Husky** ein (`core.hooksPath`). Beim **`git commit`** läuft nur **lint-staged** (Prettier auf gestagete, nicht ignorierte Dateien). **`npm run lint`** und **`npm run validate:data`** laufen dort **nicht** automatisch; vor einem Push empfiehlt sich wie in der CI **`npm run check`** (oder einzeln `lint` / `validate:data`). Ohne Pre-Commit-Hook: **`git commit --no-verify`**.
+## Git-Hooks
+
+Nach `npm ci` setzt das Skript **`prepare`** [Husky](https://typicode.github.io/husky/) auf (`core.hooksPath`). Beim **`git commit`** läuft nur **lint-staged** (**Prettier** auf vorgemerkte, nicht ignorierte Dateien). **`npm run lint`** und **`npm run validate:data`** laufen dort nicht. Vor dem Push wie in der CI **`npm run check`** ausführen (oder einzeln `lint` / `validate:data`). Hook auslassen: **`git commit --no-verify`**.
 
 ## Wichtigste Regeln
 
-- Eine Datei pro Artikel.
 - IDs und Slugs nur in Kleinbuchstaben mit Bindestrichen.
-- Felder `manufacturer`, `articleNumber`, `releaseDate`, `uvp` und `model` sind Pflicht.
-- Im `model` sind auch `scale`, `electricSystem` und `era` Pflicht.
-- Features werden unter `model.features` als Liste gepflegt, z. B. `Analog`, `Digital`, `Sound`.
-- Lüp wird als `model.luepMm` in Millimeter gepflegt.
-- Mindestradius wird als `model.minRadiusMm` in Millimeter gepflegt.
+- Pflichtfelder: `manufacturer`, `articleNumber`, `releaseDate`, `uvp`, `model`.
+- Im Objekt `model` sind zwingend `scale`, `electricSystem` und `era` gesetzt.
+- Features unter `model.features` als Liste, z. B. `Analog`, `Digital`, `Sound`.
+- Lüp als `model.luepMm` in Millimetern; Mindestradius als `model.minRadiusMm`.
 - Optional: `model.decoderInterface`, `model.variantGroup`, `model.couplerSystem`, `identifiers.ean`.
-- `description` darf frei formuliert werden und kann leer bleiben.
-- `source.url` sollte für neue oder geänderte Fakten angegeben werden.
-- Optional: `source.imageUrl` (HTTPS) für die URL des **Produktbilds**, üblicherweise von derselben Quelle wie `source.url`.
+- `description` frei formuliert, darf leer sein.
+- `source.url` bei neuen oder geänderten Fakten setzen.
+- Optional: `source.imageUrl` (HTTPS) für das Produktbild, üblicherweise dieselbe Quelle wie `source.url`.
 
-## AI-unterstützte Beiträge
+## KI-unterstützte Beiträge
 
-- AI darf verwendet werden.
-- Vor dem PR bitte immer Fakten prüfen.
-- Quellen sollen im Feld `source.url` dokumentiert werden.
-
-## Lokale Qualitätssicherung
-
-Vor dem Öffnen eines Pull Requests:
-
-- `npm ci`
-- `npm run check` (Lint, Format, Tests, Schema- und Semantikprüfung, Suchindex, Artefakt-Check)
-
-Die CI führt denselben Ablauf im Workflow **Validate Data** bei Pull Requests und bei Pushes auf `master` aus.
+KI darf genutzt werden. Vor dem PR Fakten prüfen und in `source.url` belegen.
 
 ## Dateibenennung
 
-Empfehlung: `articles/{manufacturerSlug}/{articleNumber}.json`, Beispiel `articles/roco/79824.json`.
+`articles/{manufacturerSlug}/{articleNumber}.json`, z. B. `articles/roco/79824.json`.
 
 ## Hersteller-Konfiguration
 
-Optional kann pro Hersteller eine Datei unter `config/manufacturers/{slug}.json` gepflegt werden, z. B. mit Logo-Link, Website, Beschreibung und Wikipedia-Link.
+Optional: `config/manufacturers/{slug}.json` (Logo, Website, Beschreibung, Wikipedia-Link).
 
-## Kategorien, Tags, Massstab, Stromsystem und Features
+## Taxonomie-Dateien
 
-Jeder Eintrag hat eine eigene Datei mit `description`:
+Je Eintrag eine Datei mit `description`:
 
 - `config/categories/{slug}.json`
 - `config/tags/{slug}.json`

--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # locobox2-database-data
 
+[![Validate Data](https://github.com/YannikG/locobox2-database-data/actions/workflows/validate-data.yml/badge.svg)](https://github.com/YannikG/locobox2-database-data/actions/workflows/validate-data.yml)
+[![Dispatch private database submodule sync](https://github.com/YannikG/locobox2-database-data/actions/workflows/dispatch-private-database-sync.yml/badge.svg)](https://github.com/YannikG/locobox2-database-data/actions/workflows/dispatch-private-database-sync.yml)
+
 Öffentliches Datenrepository für Locobox.
 
-## Struktur
+## Ordnerstruktur
 
-- `articles/`: Artikeldaten, eine Datei pro Artikelnummer.
-- `config/`: Taxonomie und Stammdaten (`categories`, `scales`, `tags`, `features`, `electric-systems`, `decoder-interfaces`, `manufacturers`).
-- `contracts/`: Verbindliche JSON-Schemas und Data-Contract-Dokumentation.
-- `utils/`: Python-Hilfsprogramme (Roco PDP/MCP unter `utils/roco/shop-pdp-parse/`), siehe `utils/README.md` und `utils/requirements.txt`.
-- `.agents/skills/caveman/`: optionaler Agent-Skill (kurze Kommunikation).
+- `articles/` – Artikeldaten, eine JSON-Datei pro Artikel.
+- `config/` – Taxonomie und Stammdaten (`categories`, `scales`, `tags`, `features`, `electric-systems`, `decoder-interfaces`, `manufacturers`).
+- `contracts/` – verbindliche JSON-Schemas und Erläuterungen, siehe [`contracts/README.md`](contracts/README.md).
+- `utils/` – Python-Hilfsprogramme (z. B. Roco-Shop-PDP), siehe [`utils/README.md`](utils/README.md).
 
-## Einstieg
+## Mitarbeit und Qualität
 
-- Git-Hooks: [Husky](https://typicode.github.io/husky/) mit Pre-Commit (**Prettier** auf gestagete Dateien via **lint-staged**); nach `npm ci` aktiv.
-- Regeln für Beiträge: `CONTRIBUTING.md`
-- Contract-Details: `contracts/README.md`
-- Python-Tools und venv: `utils/README.md`
+Richtlinien: [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+Nach `npm ci` aktiviert [Husky](https://typicode.github.io/husky/) Git-Hooks: beim Commit formatiert **lint-staged** mit **Prettier** die **vorgemerkten** Dateien. Lint und Datenvalidierung laufen dort nicht automatisch; vor dem Push **`npm run check`** ausführen (gleicher Ablauf wie in der CI **Validate Data**).
+
+Der Workflow **Dispatch private database submodule sync** dient der internen Synchronisation mit dem privaten Datenbank-Repository und betrifft normale Daten-PRs in der Regel nicht.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,32 +1,29 @@
 # Data Contract
 
-Diese Schemata sind die verbindliche Schnittstelle zwischen dem öffentlichen Data-Repository und der privaten Build-Pipeline.
+Diese Schemata sind die verbindliche Schnittstelle zwischen dem öffentlichen Daten-Repository und der privaten Build-Pipeline.
 
-## Enthaltene Schemata
+## Schemata
 
-- `article.schema.json` für einzelne Artikeldateien.
-- `taxonomy-item.schema.json` für einzelne Kategorien-, Tags-, Massstab- und Stromsystem-Dateien.
-- `manufacturer.schema.json` für optionale Hersteller-Metadaten pro Datei.
+- `article.schema.json` – einzelne Artikeldateien.
+- `taxonomy-item.schema.json` – Kategorien, Tags, Massstab, Stromsystem.
+- `manufacturer.schema.json` – optionale Hersteller-Metadaten pro Datei.
 
 ## Designregeln
 
-- Contributor arbeiten mit einer Datei pro Artikel.
-- Build-Prozesse transformieren die Rohdaten später in suchoptimierte Shards.
-- Änderungen an den Schemata folgen Semver und müssen dokumentiert werden.
+- Beitragende arbeiten mit einer Datei pro Artikel.
+- Build-Prozesse können Rohdaten später in suchoptimierte Shards transformieren.
+- Schemaänderungen folgen Semver und werden dokumentiert.
 - **`model.number` / `model.livery`:** dürfen `null` sein, solange Splitt oder Lackname noch offen ist (siehe Agent-Skill Loknummerierung).
 - **`releaseDate`:** `null`, ISO-Datum (`YYYY-MM-DD`), vierstelliges Jahr (`YYYY`) oder Freitext (z. B. «Frühling 2026» laut Hersteller).
 - **Taxonomie-Slugs:** dürfen Grossbuchstaben enthalten (z. B. `H0`), damit sie mit `model.scale` und Tag-Werten übereinstimmen können.
-- **`decoderInterfaces`:** optionales Feld **`aliases`** (Strings), die in Artikeln als Rohimport erlaubt sind; kanonisch bleiben `name` und `slug`.
-- **`model.electricSystem`:** Im Artikelschema als **`enum`** geführt; Werte entsprechen den Taxonomie-Dateien unter `config/electric-systems/` (je `name` und, falls abweichend, `slug`, z. B. `Other` / `other`).
-- Semantik-Checks ergänzen die Schemas, insbesondere für:
-  - ID-Konvention (`{manufacturerSlug}-{articleNumber}`)
-  - Referenzen auf Hersteller-Konfigurationen
-  - Eindeutigkeit von Taxonomie-Slugs und -Namen pro Collection
+- **`decoderInterfaces`:** optionales Feld **`aliases`** (Strings) für Rohimporte in Artikeln; kanonisch bleiben `name` und `slug`.
+- **`model.electricSystem`:** im Artikelschema als **`enum`**; Werte entsprechen den Dateien unter `config/electric-systems/` (`name` und ggf. abweichender `slug`, z. B. `Other` / `other`).
+- Semantik-Checks ergänzen die Schemas (u. a. ID `{manufacturerSlug}-{articleNumber}`, Referenzen auf Hersteller-Konfigurationen, Eindeutigkeit von Taxonomie-Slugs und -Namen pro Collection).
 
 ## Rückwärtskompatibilität
 
-- Patch: rein additive Korrekturen ohne Strukturbruch.
-- Minor: neue optionale Felder (z. B. `source.imageUrl` für PDP-Produktbilder).
-- Major: Breaking Changes mit Migrationspfad.
+- **Patch:** rein additive Korrekturen ohne Strukturbruch.
+- **Minor:** neue optionale Felder (z. B. `source.imageUrl` für PDP-Produktbilder).
+- **Major:** Breaking Changes mit Migrationspfad.
 
-Details zu Pflichtkeys, `null` und `releaseDate` stehen in **`article.schema.json`** (Kommentare in `description` wo nötig).
+Pflichtkeys, `null` und `releaseDate` sind in **`article.schema.json`** beschrieben (`description` in den betroffenen Properties).

--- a/utils/roco/README.md
+++ b/utils/roco/README.md
@@ -1,9 +1,11 @@
 # Roco-Hilfsprogramme
 
-**Abhängigkeiten:** siehe **`../requirements.txt`** und **`../README.md`** (venv, Python **3.10+** für MCP-Import und `pip install`).
+**Abhängigkeiten:** [`../requirements.txt`](../requirements.txt) und [`../README.md`](../README.md) (venv, Python **3.10+** für MCP-Import und `pip install`).
 
-| Ordner | Zweck |
-|--------|--------|
-| **`shop-pdp-parse/`** | PDP parsen (`roco_shop_parse_pdp.py`); optional Import über Chrome-MCP-stdio (`roco_mcp_chrome_search_import.py`, [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)). Derselbe `--merge-config` / `--merge-only` wie beim Parser gilt für den Importer. Presets: `merge-pdp-specs-fields.json` (Spez-Tabelle); `merge-pdp-specs-with-title-model.json` erweitert `mergeOnly` um `model.type` / `model.number` (Titel aus `og:title`). Eigene JSON nach demselben Muster möglich. **`roco_catalogue_stub.py`:** aus einer Nummernliste **nur fehlende** `articles/roco/{nr}.json` als Stub (Duplikate in der Datei entfallen; optional ``--fail-if-nothing-created``, ``--dry-run``). |
+## `shop-pdp-parse/`
 
-Alle Skripte erwarten das Repo-Root drei Ebenen über dem jeweiligen `.py`-Pfad (`parents[3]`).
+- **`roco_shop_parse_pdp.py`:** PDP parsen und JSON mergen.
+- **`roco_mcp_chrome_search_import.py`:** optionaler Import über Chrome-MCP-stdio ([MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)); gleiche Merge-Optionen wie beim Parser (`--merge-config`, `--merge-only`). Presets: `merge-pdp-specs-fields.json` (Spezifikationstabelle); `merge-pdp-specs-with-title-model.json` erweitert `mergeOnly` um `model.type` / `model.number` (Titel aus `og:title`). Eigene JSON-Dateien nach demselben Muster möglich.
+- **`roco_catalogue_stub.py`:** aus einer Nummernliste **nur fehlende** `articles/roco/{nr}.json` als Stub anlegen (Duplikate in der Liste werden ignoriert; optional `--fail-if-nothing-created`, `--dry-run`).
+
+Skripte gehen vom **Repository-Root** aus (Pfade relativ zum Repo).


### PR DESCRIPTION
Dieser Pull Request bereinigt die Projektdokumentation und richtet sie an der Schweizer Rechtschreibung aus (Umlaute, kein scharfes S).

**README:** Zwei GitHub-Actions-Badges (Validate Data, Dispatch private database submodule sync), strukturiertere Ordnerübersicht, Mitarbeit und lokale/CI-Qualitätssicherung an einem Ort, Korrektur „vorgemerkte“ statt „gestagete“ Dateien, Hinweis auf den Submodule-Sync-Workflow.

**CONTRIBUTING:** Doppelte QS-Abschnitte entfernt, Git-Hooks klar beschrieben, Regeln kompakter, einheitlich „KI-unterstützt“.

**contracts/README, PR-Template, utils/roco/README:** Formulierungen gestrafft, contracts mit „Beitragende“ und „Grossbuchstaben“, Roco-README lesbarer aufgeteilt.

Made with [Cursor](https://cursor.com)