### PR TITLE
Roco BR 110: model.type/number Split (Auto-Fix)

### DIFF
--- a/articles/roco/7300107.json
+++ b/articles/roco/7300107.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "DD",
     "operator": "DR",
-    "type": "BR 110",
-    "number": null,
+    "type": "BR",
+    "number": "110",
     "livery": "DR",
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/roco/7310107.json
+++ b/articles/roco/7310107.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "DD",
     "operator": "DR",
-    "type": "BR 110",
-    "number": null,
+    "type": "BR",
+    "number": "110",
     "livery": "DR",
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/roco/7320107.json
+++ b/articles/roco/7320107.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "DD",
     "operator": "DR",
-    "type": "BR 110",
-    "number": null,
+    "type": "BR",
+    "number": "110",
     "livery": "DR",
     "scale": "H0",
     "electricSystem": "AC-Digital",


### PR DESCRIPTION
Dieser PR wendet den mechanischen Loknummerierungs-Auto-Fix (`autofix_model_type_number_split.py --include-br`) auf die drei Schwester-Artikel Roco BR 110 (DC-Analog / DC-Digital / AC-Digital) an.

**Geänderte Dateien**
- `articles/roco/7300107.json` — `model.type` / `model.number`: `BR 110` / `null` → `BR` / `110`
- `articles/roco/7310107.json` — gleich
- `articles/roco/7320107.json` — gleich

**Hintergrund**
- Skill `lok-numbering-article-review`: Allowlist-Regel `br_class` mit optional `--include-br`.
- `npm run validate:data` lokal grün.

**Review-Hinweis (optional, kein Blocker)**
- `model.livery` ist weiterhin `DR`; in der Beschreibung steht «bordeauxrote Lackierung» — kann in einem Folge-PR verfeinert werden.

Made with [Cursor](https://cursor.com)