### PR TITLE
Roco Herbstneuheiten 2025: Artikel, Tag und type/number-Autofix

### DIFF
--- a/articles/roco/7110048.json
+++ b/articles/roco/7110048.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7110048",
+  "manufacturer": "Roco",
+  "articleNumber": "7110048",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 349.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "kkStB",
+    "type": "85.13",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX16",
+    "era": "I",
+    "luepMm": 79,
+    "minRadiusMm": 358
+  },
+  "description": "Dampflokomotive 85.13 der kaiserlich-königlichen österreichischen Staatsbahnen. Aufwendige Bedruckung mit feinen Zierlinien. Detaillierte Ausführung der Steuerung. Modell mit vielen separat angesetzten SteckteilenAls die wichtigsten Eisenbahnstrecken im Wesentlichen ausgebaut waren und der Vorteil der erschlossenen Wirtschaftsgebiete sichtbar wurde, zeigte sich ein Zurückbleiben abgelegener Landstriche. Man ging daran diese Gebiete durch den Bau von „Secundärbahnen“ zu erschliessen. Mit dem Bau der einfach gehaltenen Lokalbahnen konnten unzählige Städtchen und Dörfer mit der grossen, weiten Welt verbunden werden.",
+  "categories": [
+    "lokomotive",
+    "dampflokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/home-neuheiten/7110048-dampflokomotive-8513-kkstb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/265167.jpg"
+  },
+  "updatedAt": "2026-05-06T19:21:46Z"
+}

--- a/articles/roco/7300081.json
+++ b/articles/roco/7300081.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7300081",
+  "manufacturer": "Roco",
+  "articleNumber": "7300081",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 174.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PMT",
+    "type": "232",
+    "number": "049",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "V-VI",
+    "luepMm": 237,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellokomotive BR-232 049 der Pol-Miedz Trans. Ausführung in auffälliger Lackierung. Einsatz im schweren Güterzugdienst. Zugkräftiges, betriebssicheres Modell für vorbildgerecht lange Züge",
+  "categories": [
+    "lokomotive",
+    "diesellokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/home-neuheiten/7300081-diesellokomotive-br-232-049-pmt.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/264560.jpg"
+  },
+  "updatedAt": "2026-05-06T19:21:57Z"
+}

--- a/articles/roco/7300102.json
+++ b/articles/roco/7300102.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7300102",
+  "manufacturer": "Roco",
+  "articleNumber": "7300102",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 399.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "V 188",
+    "number": "002",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "III",
+    "luepMm": 259,
+    "minRadiusMm": 358
+  },
+  "description": "Dieselelektrische Doppellokomotive V 188 002 der Deutschen Bundesbahn.Edition-Modell!Formvariante!. Epoche-IIIb-Ausführung in roter Lackierung. Entlüftungsbauteil am Dach, Rohr mit pilzförmiger Abdeckung. Je ein Batteriekasten rechts hinten auf der Lokhälfte. Doppellok gebildet aus zwei fix miteinander gekuppelten Einheiten; beide Einheiten vollwertig mit Motor ausgerüstet. Vollständige Nachbildung des Übergangsbereichs zwischen den beiden Einheiten. Aufwendig nachgebildeter Maschinenraum. Fein detailliertes Modell mit separat angesetzten Steckteilen. Rahmenblenden mit je 4 Sandkästen. Fahrtrichtungsabhängiges 3-Spitzenlicht und zwei rote Schlussleuchten. Durchbrochen dargestellte Dachlüfter. Führerstands-, Führerpult- und Schaltkastenbeleuchtung sowie Maschinenraumbeleuchtung eingebaut; im Digitalbetrieb schaltbar1941 und 1942 wurden insgesamt vier Doppellokomotiven der Type D 311 von der Deutschen Wehrmacht in Dienst gestellt. Sie waren für den Transport schwerer Eisenbahngeschütze gebaut worden. Zwei Lokomotiven, die V 188 001 a/b und die V 188 002 a/b wurden nach dem Krieg von der Deutschen Bundesbahn weiter eingesetzt. Eine dritte Lokomotive diente als Ersatzteilspender. Sie bewährten sich im schweren Güterzug- und Schiebedienst, vorwiegend auf der Spessart-Rampe. Nach einem Generatorschaden musste die V 188 001 bereits 1968 abgestellt werden. V 188 002, später 288 002 war noch bis 1972 im Fränkischen Raum in Betrieb. 1973 wurden beide Maschinen verschrottet.",
+  "categories": [
+    "lokomotive",
+    "diesellokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300102-dieselelektrische-doppellokomotive-v-188-002-db.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/265436.jpg"
+  },
+  "updatedAt": "2026-05-06T19:22:08Z"
+}

--- a/articles/roco/7310081.json
+++ b/articles/roco/7310081.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7310081",
+  "manufacturer": "Roco",
+  "articleNumber": "7310081",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 274.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PMT",
+    "type": "232",
+    "number": "049",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "V-VI",
+    "luepMm": 237,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellokomotive BR-232 049 der Pol-Miedz Trans. Ausführung in auffälliger Lackierung. Einsatz im schweren Güterzugdienst. Zugkräftiges, betriebssicheres Modell für vorbildgerecht lange Züge. Im Digitalbetrieb mit schaltbarem Rangierlicht und einzeln schaltbarem Spitzen- oder Schlusslicht",
+  "categories": [
+    "lokomotive",
+    "diesellokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/home-neuheiten/7310081-diesellokomotive-br-232-049-pmt.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/264561.jpg"
+  },
+  "updatedAt": "2026-05-06T19:22:19Z"
+}

--- a/articles/roco/7310084.json
+++ b/articles/roco/7310084.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7310084",
+  "manufacturer": "Roco",
+  "articleNumber": "7310084",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 259.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "IT",
+    "operator": "FVS",
+    "type": "L.D.61",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge Next18",
+    "era": "III-IV",
+    "luepMm": 106,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellokomotive L.D.61 der Ferrovia della Valle Seriana. Erstmals mit neuer Schnittstelle Next18. Ausführung mit Glocke am Vorbau. Ideale Ergänzung zum Nebenbahngüterzug, Art.-Nr. 6600229. Im Digitalbetrieb mit schaltbarem RangierlichtDie Diesellokomotiven vom Typ WR 360 C 14 wurden ursprünglich von der deutschen Wehrmacht für den Einsatz an strategisch wichtigen Punkten eingesetzt. Für die Ferrovia della Valle Seriana (FVS) wurden in den Jahren 1953/54 zwei von der Firma Greco in Reggio Emilia, in Lizenz von Deutz gebaute, Lokomotiven des Typs V 36 für den Rangier- und Zugbetrieb angeschafft.",
+  "categories": [
+    "lokomotive",
+    "diesellokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310084-diesellokomotive-ld61-fvs.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/264599.jpg"
+  },
+  "updatedAt": "2026-05-06T19:22:30Z"
+}

--- a/articles/roco/7310102.json
+++ b/articles/roco/7310102.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7310102",
+  "manufacturer": "Roco",
+  "articleNumber": "7310102",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 599.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "V 188",
+    "number": "002",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "III",
+    "luepMm": 259,
+    "minRadiusMm": 358
+  },
+  "description": "Dieselelektrische Doppellokomotive V 188 002 der Deutschen Bundesbahn.Edition-Modell!Formvariante!. Epoche-IIIb-Ausführung in roter Lackierung. Entlüftungsbauteil am Dach, Rohr mit pilzförmiger Abdeckung. Je ein Batteriekasten rechts hinten auf der Lokhälfte. Doppellok gebildet aus zwei fix miteinander gekuppelten Einheiten; beide Einheiten vollwertig mit Motor ausgerüstet. Vollständige Nachbildung des Übergangsbereichs zwischen den beiden Einheiten. Aufwendig nachgebildeter Maschinenraum. Fein detailliertes Modell mit separat angesetzten Steckteilen. Rahmenblenden mit je 4 Sandkästen. Fahrtrichtungsabhängiges 3-Spitzenlicht und zwei rote Schlussleuchten. Durchbrochen dargestellte Dachlüfter. Digitalversion mit motorisch angetriebenen Ventilatoren. Im Digitalbetrieb mit schaltbarer Führerstands-, Führerpult- und Schaltkastenbeleuchtung sowie Maschinenraumbeleuchtung. „Dynamic Sound“-Paket für noch besseren Tiefenklang1941 und 1942 wurden insgesamt vier Doppellokomotiven der Type D 311 von der Deutschen Wehrmacht in Dienst gestellt. Sie waren für den Transport schwerer Eisenbahngeschütze gebaut worden. Zwei Lokomotiven, die V 188 001 a/b und die V 188 002 a/b wurden nach dem Krieg von der Deutschen Bundesbahn weiter eingesetzt. Eine dritte Lokomotive diente als Ersatzteilspender. Sie bewährten sich im schweren Güterzug- und Schiebedienst, vorwiegend auf der Spessart-Rampe. Nach einem Generatorschaden musste die V 188 001 bereits 1968 abgestellt werden. V 188 002, später 288 002 war noch bis 1972 im Fränkischen Raum in Betrieb. 1973 wurden beide Maschinen verschrottet.",
+  "categories": [
+    "lokomotive",
+    "diesellokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7310102-dieselelektrische-doppellokomotive-v-188-002-db.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/265437.jpg"
+  },
+  "updatedAt": "2026-05-06T19:22:41Z"
+}

--- a/articles/roco/7320102.json
+++ b/articles/roco/7320102.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7320102",
+  "manufacturer": "Roco",
+  "articleNumber": "7320102",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 599.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "V 188",
+    "number": "002",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "III",
+    "luepMm": 259,
+    "minRadiusMm": 358
+  },
+  "description": "Dieselelektrische Doppellokomotive V 188 002 der Deutschen Bundesbahn.Edition-Modell!Formvariante!. Epoche-IIIb-Ausführung in roter Lackierung. Entlüftungsbauteil am Dach, Rohr mit pilzförmiger Abdeckung. Je ein Batteriekasten rechts hinten auf der Lokhälfte. Doppellok gebildet aus zwei fix miteinander gekuppelten Einheiten; beide Einheiten vollwertig mit Motor ausgerüstet. Vollständige Nachbildung des Übergangsbereichs zwischen den beiden Einheiten. Aufwendig nachgebildeter Maschinenraum. Fein detailliertes Modell mit separat angesetzten Steckteilen. Rahmenblenden mit je 4 Sandkästen. Fahrtrichtungsabhängiges 3-Spitzenlicht und zwei rote Schlussleuchten. Durchbrochen dargestellte Dachlüfter. Digitalversion mit motorisch angetriebenen Ventilatoren. Im Digitalbetrieb mit schaltbarer Führerstands-, Führerpult- und Schaltkastenbeleuchtung sowie Maschinenraumbeleuchtung. „Dynamic Sound“-Paket für noch besseren Tiefenklang1941 und 1942 wurden insgesamt vier Doppellokomotiven der Type D 311 von der Deutschen Wehrmacht in Dienst gestellt. Sie waren für den Transport schwerer Eisenbahngeschütze gebaut worden. Zwei Lokomotiven, die V 188 001 a/b und die V 188 002 a/b wurden nach dem Krieg von der Deutschen Bundesbahn weiter eingesetzt. Eine dritte Lokomotive diente als Ersatzteilspender. Sie bewährten sich im schweren Güterzug- und Schiebedienst, vorwiegend auf der Spessart-Rampe. Nach einem Generatorschaden musste die V 188 001 bereits 1968 abgestellt werden. V 188 002, später 288 002 war noch bis 1972 im Fränkischen Raum in Betrieb. 1973 wurden beide Maschinen verschrottet.",
+  "categories": [
+    "lokomotive",
+    "diesellokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7320102-dieselelektrische-doppellokomotive-v-188-002-db.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/265438.jpg"
+  },
+  "updatedAt": "2026-05-06T19:22:52Z"
+}

--- a/articles/roco/7500166.json
+++ b/articles/roco/7500166.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7500166",
+  "manufacturer": "Roco",
+  "articleNumber": "7500166",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 254.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "BE",
+    "operator": "SNCB",
+    "type": "186",
+    "number": "119-1",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 186 119 (2869) der Belgischen Staatsbahnen. Ausführung im aktuellen Design. Mit detaillierter Dachgestaltung. Mit separat angesetzten Steckteilen teilweise in Ätztechnik ausgeführt. Schaltbares Spitzen-/Schlusslicht mit DIP-SchalterDie Belgischen Staatsbahnen nahmen im Dezember 2024 neue Direktzüge zwischen Brüssel und Rotterdam in Betrieb. Für diesen Einsatz mietete die SNCB/NMBS von Alpha Trains, zusätzlich zu den vorhandenen Maschinen, die Lokomotiven 186 119-122 (vorher bei den Niederländischen Staatsbahnen). Sie erhielten damit das aktuelle Design der SNCB/NMBS.Mit Genehmigung von NMBS Train World.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500166-elektrolokomotive-186-119-1-sncb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/264636.jpg"
+  },
+  "updatedAt": "2026-05-06T19:23:03Z"
+}

--- a/articles/roco/7500208.json
+++ b/articles/roco/7500208.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7500208",
+  "manufacturer": "Roco",
+  "articleNumber": "7500208",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 0.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "1116",
+    "number": "238-7",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 1116 238 der Österreichischen Bundesbahnen.Modell ausgerüstet mit NEM-Schacht, es liegt ein Kupplungsadapter für den Einsatz vor Railjet-Modellen bei, welche ab Werk mit elektrischer Kupplung ausgerüstet sind. Aktueller Betriebszustand mit Piktogrammen auf der Pufferbohle. Im Einsatz vor den ÖBB Railjet Zügen aber auch vor vielen anderen Zuggattungen. Schaltbares Spitzen-/Schlusslicht mit DIP-Schalter. Lizenziertes ÖBB-Modell. Z21 Führerstand verfügbarMit der Indienststellung der ersten „Taurus“-Lokomotive Reihe 1016 im Sommer 1999 begann die rasante Modernisierung der österreichischen E-Lok-Flotte. Von dieser Universallokomotive wurde auch eine Zweisystemausführung für den Wechselstrombetrieb mit 15 kV/16,7 Hz sowie 25 kV/50 Hz beschafft. Bis 2006 wurden 282 Lokomotiven der Reihe 1116 in Dienst gestellt. Sie sind für 230 km/h zugelassen. Die Leistung beträgt 6.400 kW.Der Railjet ist ein bedeutender Bestandteil des europäischen Fernverkehrs und verbindet nicht nur wichtige Städte in Österreich, sondern auch internationale Destinationen. Die Lokomotiven 1116.201–251 wurden bei Siemens in München für die seit Dezember 2008 eingeführten Railjet-Verkehre adaptiert. 1116 238 erhielt im Mai 2011 die Ausrüstung dafür.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500208-elektrolokomotive-1116-238-7-railjet-obb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/266178.jpg"
+  },
+  "updatedAt": "2026-05-06T19:23:15Z"
+}

--- a/articles/roco/7500209.json
+++ b/articles/roco/7500209.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7500209",
+  "manufacturer": "Roco",
+  "articleNumber": "7500209",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 0.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "1116",
+    "number": "014-2",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 1116 014 der Österreichischen Bundesbahnen. Rail Cargo Hungaria Schriftzug auf der Seitenwand. Unterschiedliche Pufferschürzen: Front 1 – SIEMENS und Krauss Maffei, Front 2 nur SIEMENS. Grenzüberschreitender Einsatz im Güterverkehr. Schaltbares Spitzen-/Schlusslicht mit DIP-Schalter. Z21 Führerstand verfügbarMit der Indienststellung der ersten „Taurus“-Lokomotive Reihe 1016 im Sommer 1999 begann die rasante Modernisierung der österreichischen E-Lok-Flotte. Von dieser Universallokomotive wurde auch eine Zweisystemausführung für den Wechselstrombetrieb mit 15 kV/16,7 Hz sowie 25 kV/50 Hz beschafft. Bis 2006 wurden 282 Lokomotiven der Reihe 1116 in Dienst gestellt. Sie sind für 230 km/h zugelassen. Die Leistung beträgt 6.400 kW.Im Jahr 2008 kaufte die RCA die Güterverkehrssparte der ungarischen Bahn (MAV Cargo Rt.). Seitdem ist Rail Cargo Hungaria Mitglied der Rail Cargo Group. Für die Traktion der Verkehre im Einsatzgebiet sind ihr die Lokomotiven 1116 001–034, 048 und 049 zugeteilt. Die 1116 014 ist mit dem Länderpaket für Österreich, Deutschland, Ungarn, Tschechien und Schweiz ausgestattet.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7500209-elektrolokomotive-1116-014-2-obb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/266181.jpg"
+  },
+  "updatedAt": "2026-05-06T19:23:27Z"
+}

--- a/articles/roco/7510065.json
+++ b/articles/roco/7510065.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7510065",
+  "manufacturer": "Roco",
+  "articleNumber": "7510065",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 399.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CH",
+    "operator": "SBB Cargo International",
+    "type": "193",
+    "number": "459-5",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 193 459 „Deutschlandpiercer“ der SBB Cargo International.Platinen-Update!. Ausführung des Schienenräumers und der Drehgestellblenden entsprechend den XLoad-Maschinen. Taufname „Bundestag Berlin“. Mehrfarbig gestaltetes Bedienpult und Führerstandsrückwand. Mit detaillierter Dachgestaltung. Grenzüberschreitender Einsatz im Güterverkehr. Im Digitalbetrieb erstmals mit schaltbaren Lichtfunktionen für CH, EU und IT. In Kooperation mit Railcolor DesignIm April 2025 wurden die letzten beiden noch nicht folierten XLoad-Vectron 193 452 und 459 beklebt. Damit ist die Serie der speziell folierten XLoad-Flotte, die bisher von der Regelausführung abweichend gestaltet wurden, auf nunmehr vier Exemplare gewachsen. Nach Holland und Italien haben nun auch die beiden Länder Deutschland und Schweiz bei SBB Cargo International eine eigene Piercer-Sonderlok erhalten. Anders als der silberne Italienpiercer hat die 193 459 beidseitig das gleiche Aussehen und trägt diverse für Deutschland bekannte Sujets.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510065-elektrolokomotive-193-459-5-deutschlandpiercer-sbb-cargo-international.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/5/256945.jpg"
+  },
+  "updatedAt": "2026-05-06T19:23:38Z"
+}

--- a/articles/roco/7510208.json
+++ b/articles/roco/7510208.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7510208",
+  "manufacturer": "Roco",
+  "articleNumber": "7510208",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 344.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "1116",
+    "number": "238-7",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 1116 238 der Österreichischen Bundesbahnen.Modell ausgerüstet mit NEM-Schacht, es liegt ein Kupplungsadapter für den Einsatz vor Railjet-Modellen bei, welche ab Werk mit elektrischer Kupplung ausgerüstet sind. Aktueller Betriebszustand mit Piktogrammen auf der Pufferbohle. Im Einsatz vor den ÖBB Railjet Zügen aber auch vor vielen anderen Zuggattungen. Im Digitalbetrieb mit schaltbarem Fernlicht und schaltbarem Spitzen-/Schlusslicht. Lizenziertes ÖBB-Modell. Z21 Führerstand verfügbarMit der Indienststellung der ersten „Taurus“-Lokomotive Reihe 1016 im Sommer 1999 begann die rasante Modernisierung der österreichischen E-Lok-Flotte. Von dieser Universallokomotive wurde auch eine Zweisystemausführung für den Wechselstrombetrieb mit 15 kV/16,7 Hz sowie 25 kV/50 Hz beschafft. Bis 2006 wurden 282 Lokomotiven der Reihe 1116 in Dienst gestellt. Sie sind für 230 km/h zugelassen. Die Leistung beträgt 6.400 kW.Der Railjet ist ein bedeutender Bestandteil des europäischen Fernverkehrs und verbindet nicht nur wichtige Städte in Österreich, sondern auch internationale Destinationen. Die Lokomotiven 1116.201–251 wurden bei Siemens in München für die seit Dezember 2008 eingeführten Railjet-Verkehre adaptiert. 1116 238 erhielt im Mai 2011 die Ausrüstung dafür.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510208-elektrolokomotive-1116-238-7-railjet-obb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/266179.jpg"
+  },
+  "updatedAt": "2026-05-06T19:23:51Z"
+}

--- a/articles/roco/7510209.json
+++ b/articles/roco/7510209.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7510209",
+  "manufacturer": "Roco",
+  "articleNumber": "7510209",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 344.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "1116",
+    "number": "014-2",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "V",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 1116 014 der Österreichischen Bundesbahnen. Rail Cargo Hungaria Schriftzug auf der Seitenwand. Unterschiedliche Pufferschürzen: Front 1 – SIEMENS und Krauss Maffei, Front 2 nur SIEMENS. Grenzüberschreitender Einsatz im Güterverkehr. Im Digitalbetrieb mit schaltbarem Fernlicht und schaltbarem Spitzen-/Schlusslicht. Z21 Führerstand verfügbarMit der Indienststellung der ersten „Taurus“-Lokomotive Reihe 1016 im Sommer 1999 begann die rasante Modernisierung der österreichischen E-Lok-Flotte. Von dieser Universallokomotive wurde auch eine Zweisystemausführung für den Wechselstrombetrieb mit 15 kV/16,7 Hz sowie 25 kV/50 Hz beschafft. Bis 2006 wurden 282 Lokomotiven der Reihe 1116 in Dienst gestellt. Sie sind für 230 km/h zugelassen. Die Leistung beträgt 6.400 kW.Im Jahr 2008 kaufte die RCA die Güterverkehrssparte der ungarischen Bahn (MAV Cargo Rt.). Seitdem ist Rail Cargo Hungaria Mitglied der Rail Cargo Group. Für die Traktion der Verkehre im Einsatzgebiet sind ihr die Lokomotiven 1116 001–034, 048 und 049 zugeteilt. Die 1116 014 ist mit dem Länderpaket für Österreich, Deutschland, Ungarn, Tschechien und Schweiz ausgestattet.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7510209-elektrolokomotive-1116-014-2-obb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/266182.jpg"
+  },
+  "updatedAt": "2026-05-06T19:24:03Z"
+}

--- a/articles/roco/7520065.json
+++ b/articles/roco/7520065.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7520065",
+  "manufacturer": "Roco",
+  "articleNumber": "7520065",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 399.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CH",
+    "operator": "SBB Cargo International",
+    "type": "193",
+    "number": "459-5",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 193 459 „Deutschlandpiercer“ der SBB Cargo International.Platinen-Update!. Ausführung des Schienenräumers und der Drehgestellblenden entsprechend den XLoad-Maschinen. Taufname „Bundestag Berlin“. Mehrfarbig gestaltetes Bedienpult und Führerstandsrückwand. Mit detaillierter Dachgestaltung. Grenzüberschreitender Einsatz im Güterverkehr. Im Digitalbetrieb erstmals mit schaltbaren Lichtfunktionen für CH, EU und IT. In Kooperation mit Railcolor DesignIm April 2025 wurden die letzten beiden noch nicht folierten XLoad-Vectron 193 452 und 459 beklebt. Damit ist die Serie der speziell folierten XLoad-Flotte, die bisher von der Regelausführung abweichend gestaltet wurden, auf nunmehr vier Exemplare gewachsen. Nach Holland und Italien haben nun auch die beiden Länder Deutschland und Schweiz bei SBB Cargo International eine eigene Piercer-Sonderlok erhalten. Anders als der silberne Italienpiercer hat die 193 459 beidseitig das gleiche Aussehen und trägt diverse für Deutschland bekannte Sujets.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520065-elektrolokomotive-193-459-5-deutschlandpiercer-sbb-cargo-international.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/5/256949.jpg"
+  },
+  "updatedAt": "2026-05-06T19:24:14Z"
+}

--- a/articles/roco/7520166.json
+++ b/articles/roco/7520166.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7520166",
+  "manufacturer": "Roco",
+  "articleNumber": "7520166",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 354.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "BE",
+    "operator": "SNCB",
+    "type": "186",
+    "number": "119-1",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 186 119 (2869) der Belgischen Staatsbahnen. Ausführung im aktuellen Design. Mit detaillierter Dachgestaltung. Mit separat angesetzten Steckteilen teilweise in Ätztechnik ausgeführt. Im Digitalbetrieb mit schaltbarem Fernlicht und schaltbarem Spitzen-/SchlusslichtDie Belgischen Staatsbahnen nahmen im Dezember 2024 neue Direktzüge zwischen Brüssel und Rotterdam in Betrieb. Für diesen Einsatz mietete die SNCB/NMBS von Alpha Trains, zusätzlich zu den vorhandenen Maschinen, die Lokomotiven 186 119-122 (vorher bei den Niederländischen Staatsbahnen). Sie erhielten damit das aktuelle Design der SNCB/NMBS.Mit Genehmigung von NMBS Train World.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520166-elektrolokomotive-186-119-1-sncb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/264638.jpg"
+  },
+  "updatedAt": "2026-05-06T19:24:25Z"
+}

--- a/articles/roco/7520208.json
+++ b/articles/roco/7520208.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7520208",
+  "manufacturer": "Roco",
+  "articleNumber": "7520208",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 0.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "1116",
+    "number": "238-7",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "VI",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolokomotive 1116 238 der Österreichischen Bundesbahnen.Modell ausgerüstet mit NEM-Schacht, es liegt ein Kupplungsadapter für den Einsatz vor Railjet-Modellen bei, welche ab Werk mit elektrischer Kupplung ausgerüstet sind. Aktueller Betriebszustand mit Piktogrammen auf der Pufferbohle. Im Einsatz vor den ÖBB Railjet Zügen aber auch vor vielen anderen Zuggattungen. Im Digitalbetrieb mit schaltbarem Fernlicht und schaltbarem Spitzen-/Schlusslicht. Lizenziertes ÖBB-Modell. Z21 Führerstand verfügbarMit der Indienststellung der ersten „Taurus“-Lokomotive Reihe 1016 im Sommer 1999 begann die rasante Modernisierung der österreichischen E-Lok-Flotte. Von dieser Universallokomotive wurde auch eine Zweisystemausführung für den Wechselstrombetrieb mit 15 kV/16,7 Hz sowie 25 kV/50 Hz beschafft. Bis 2006 wurden 282 Lokomotiven der Reihe 1116 in Dienst gestellt. Sie sind für 230 km/h zugelassen. Die Leistung beträgt 6.400 kW.Der Railjet ist ein bedeutender Bestandteil des europäischen Fernverkehrs und verbindet nicht nur wichtige Städte in Österreich, sondern auch internationale Destinationen. Die Lokomotiven 1116.201–251 wurden bei Siemens in München für die seit Dezember 2008 eingeführten Railjet-Verkehre adaptiert. 1116 238 erhielt im Mai 2011 die Ausrüstung dafür.",
+  "categories": [
+    "lokomotive",
+    "elektrolokomotive"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/7520208-elektrolokomotive-1116-238-7-railjet-obb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/6/266180.jpg"
+  },
+  "updatedAt": "2026-05-06T19:24:36Z"
+}

--- a/articles/roco/7700014.json
+++ b/articles/roco/7700014.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7700014",
+  "manufacturer": "Roco",
+  "articleNumber": "7700014",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 274.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CH",
+    "operator": "SBB",
+    "type": "De 4/4",
+    "number": "1669",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "IV",
+    "luepMm": 175,
+    "minRadiusMm": 358
+  },
+  "description": "Elektro-Gepäcktriebwagen De 4/4 1669 der Schweizerischen Bundesbahnen. Erstmals mit PluX22-Schnittstelle und LED-Beleuchtung in dieser Ausführung. Fenster im Gepäckraum mit Gitterstangen-NachbildungInsgesamt 11 Fe 4/4 erhielten in den Jahren 1930/1931 sowie 1938 eine elektrische Bremse für deren Einsatz auf der Seetalbahn sowie der steilen Strecke Vallorbe – Le Pont. Nach der Entscheidung, diese Teilserie einer Modernisierung zu unterziehen, baute die Werkstätte Yverdon 1965/1966 den De 4/4 1669 um. Er sollte damals als Muster dienen, gehörte dem Depot Lausanne an und stand vor der Fälligkeit der Hauptrevision. Der umgebaute Triebwagen erhielt unter anderem folgende Neuerungen: Führerstand für sitzende Bedienung, neue pneumatische Apparate, Drucklufthauptschalter, neue Hüpferbatterie und eine geschlossene Zugführerkabine. Klassisch blieb lediglich sein dunkelgrünes Farbkleid mit hellgrauem Untergestell.",
+  "categories": [
+    "lokomotive",
+    "triebzug"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7700014-elektro-gepacktriebwagen-de-44-1669-sbb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/5/258670.jpg"
+  },
+  "updatedAt": "2026-05-06T19:24:48Z"
+}

--- a/articles/roco/7710014.json
+++ b/articles/roco/7710014.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7710014",
+  "manufacturer": "Roco",
+  "articleNumber": "7710014",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 374.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CH",
+    "operator": "SBB",
+    "type": "De 4/4",
+    "number": "1669",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "IV",
+    "luepMm": 175,
+    "minRadiusMm": 358
+  },
+  "description": "Elektro-Gepäcktriebwagen De 4/4 1669 der Schweizerischen Bundesbahnen. Erstmals mit PluX22-Schnittstelle und LED-Beleuchtung in dieser Ausführung. Fenster im Gepäckraum mit Gitterstangen-Nachbildung. Im Digitalbetrieb mit schaltbarer Führerstands- und Maschinenraumbeleuchtung. Mit authentischen SoundfunktionenInsgesamt 11 Fe 4/4 erhielten in den Jahren 1930/1931 sowie 1938 eine elektrische Bremse für deren Einsatz auf der Seetalbahn sowie der steilen Strecke Vallorbe – Le Pont. Nach der Entscheidung, diese Teilserie einer Modernisierung zu unterziehen, baute die Werkstätte Yverdon 1965/1966 den De 4/4 1669 um. Er sollte damals als Muster dienen, gehörte dem Depot Lausanne an und stand vor der Fälligkeit der Hauptrevision. Der umgebaute Triebwagen erhielt unter anderem folgende Neuerungen: Führerstand für sitzende Bedienung, neue pneumatische Apparate, Drucklufthauptschalter, neue Hüpferbatterie und eine geschlossene Zugführerkabine. Klassisch blieb lediglich sein dunkelgrünes Farbkleid mit hellgrauem Untergestell.",
+  "categories": [
+    "lokomotive",
+    "triebzug"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7710014-elektro-gepacktriebwagen-de-44-1669-sbb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/5/258673.jpg"
+  },
+  "updatedAt": "2026-05-06T19:25:03Z"
+}

--- a/articles/roco/7720014.json
+++ b/articles/roco/7720014.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "roco-7720014",
+  "manufacturer": "Roco",
+  "articleNumber": "7720014",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 374.9,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CH",
+    "operator": "SBB",
+    "type": "De 4/4",
+    "number": "1669",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Analog",
+    "decoderInterface": "Elektrische Schnittstelle für Triebfahrzeuge PluX22",
+    "era": "IV",
+    "luepMm": 175,
+    "minRadiusMm": 358
+  },
+  "description": "Elektro-Gepäcktriebwagen De 4/4 1669 der Schweizerischen Bundesbahnen. Erstmals mit PluX22-Schnittstelle und LED-Beleuchtung in dieser Ausführung. Fenster im Gepäckraum mit Gitterstangen-Nachbildung. Im Digitalbetrieb mit schaltbarer Führerstands- und Maschinenraumbeleuchtung. Mit authentischen SoundfunktionenInsgesamt 11 Fe 4/4 erhielten in den Jahren 1930/1931 sowie 1938 eine elektrische Bremse für deren Einsatz auf der Seetalbahn sowie der steilen Strecke Vallorbe – Le Pont. Nach der Entscheidung, diese Teilserie einer Modernisierung zu unterziehen, baute die Werkstätte Yverdon 1965/1966 den De 4/4 1669 um. Er sollte damals als Muster dienen, gehörte dem Depot Lausanne an und stand vor der Fälligkeit der Hauptrevision. Der umgebaute Triebwagen erhielt unter anderem folgende Neuerungen: Führerstand für sitzende Bedienung, neue pneumatische Apparate, Drucklufthauptschalter, neue Hüpferbatterie und eine geschlossene Zugführerkabine. Klassisch blieb lediglich sein dunkelgrünes Farbkleid mit hellgrauem Untergestell.",
+  "categories": [
+    "lokomotive",
+    "triebzug"
+  ],
+  "tags": [
+    "roco-herbstneuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.roco.cc/rde/produkte/lokomotiven/triebzuge/7720014-elektro-gepacktriebwagen-de-44-1669-sbb.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.roco.cc/media/catalog/product/cache/7ee44aa0126bc9176198779df8fa359f/2/5/258675.jpg"
+  },
+  "updatedAt": "2026-05-06T19:25:14Z"
+}

--- a/config/tags/roco-herbstneuheiten-2025.json
+++ b/config/tags/roco-herbstneuheiten-2025.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": "1.0.0",
+  "name": "Roco Herbstneuheiten 2025",
+  "slug": "roco-herbstneuheiten-2025",
+  "description": "Artikel aus dem Roco-Herbstneuheitenkatalog 2025."
+}

--- a/utils/agents/lok-numbering-article-review/scripts/autofix_model_type_number_split.py
+++ b/utils/agents/lok-numbering-article-review/scripts/autofix_model_type_number_split.py
@@ -9,6 +9,8 @@ and ``SKILL.md`` (Auto-Fix Splitting).
 * Only runs when ``model.number`` is null (no overwrites of explicit numbers).
 * Skips ``model.type`` that contain marketing quotes (``„"«»``) or are very long.
 * Optional steam rule requires ``dampflokomotive`` + URL slug confirmation.
+* ``BR-<digits> <digits>`` (z. B. Roco PMT «BR-232 049») → ``type`` = Baureihe, ``number`` = Betriebsnummer.
+* Drei- oder vierstellige Reihe + ``NNN-d`` + optionaler Taufname in ``„"«`` am Ende des ``type``-Strings (z. B. «1116 238-7 „Railjet"», «193 459-5 „Deutschlandpiercer"»).
 
 Usage::
 
@@ -131,11 +133,46 @@ def _apply_regex_rules(t: str) -> Optional[Proposal]:
     if m:
         return ("m62_dash", "M62", m.group(1))
 
+    # z. B. «BR-232 049» (PMT / Roco-Slug): Baureihe ohne «BR-»-Präfix, Nummer separat
+    m = re.fullmatch(r"BR-(\d+) (\d+)", t)
+    if m:
+        return ("br_hyphen_nn", m.group(1), m.group(2))
+
     m = re.fullmatch(r"(\d{3}) (\d{3}-\d)", t)
     if m:
         return ("uic_3_dash", m.group(1), m.group(2))
 
     return None
+
+
+def _rule_4digit_3dash_taufname(t: str) -> Optional[Proposal]:
+    """
+    Vierstellige Baureihe + ``NNN-d`` + optionaler Taufname in Typografik-Anführungszeichen
+    (z. B. ÖBB «1116 238-7 „Railjet"»), trotz ``_skip_type_marketing``.
+    """
+    t_st = t.strip()
+    m = re.match(
+        r"^(\d{4})\s+(\d{3}-\d)(?:\s+[\u201e\u201c\u00ab\"].+)?$",
+        t_st,
+    )
+    if not m:
+        return None
+    return ("series_4_3dash_tail", m.group(1), m.group(2))
+
+
+def _rule_3digit_3dash_taufname(t: str) -> Optional[Proposal]:
+    """
+    Dreistellige Baureihe + ``NNN-d`` + optionaler Taufname in Typografik-Anführungszeichen
+    (z. B. «193 459-5 „Deutschlandpiercer"»), trotz ``_skip_type_marketing``.
+    """
+    t_st = t.strip()
+    m = re.match(
+        r"^(\d{3})\s+(\d{3}-\d)(?:\s+[\u201e\u201c\u00ab\"].+)?$",
+        t_st,
+    )
+    if not m:
+        return None
+    return ("series_3_3dash_tail", m.group(1), m.group(2))
 
 
 def propose_split(article: Article, *, include_br: bool = False) -> Optional[Proposal]:
@@ -149,6 +186,13 @@ def propose_split(article: Article, *, include_br: bool = False) -> Optional[Pro
     steam = _rule_steam_2_4(article)
     if steam:
         return steam
+
+    tauf4 = _rule_4digit_3dash_taufname(t)
+    if tauf4:
+        return tauf4
+    tauf3 = _rule_3digit_3dash_taufname(t)
+    if tauf3:
+        return tauf3
 
     if not _skip_type_marketing(t):
         p = _apply_regex_rules(t)

--- a/utils/agents/lok-numbering-article-review/scripts/test_autofix_model_type_number_split.py
+++ b/utils/agents/lok-numbering-article-review/scripts/test_autofix_model_type_number_split.py
@@ -62,6 +62,23 @@ class TestProposeSplit(unittest.TestCase):
             m.propose_split(art, include_br=True), ("br_class", "BR", "110")
         )
 
+    def test_br_hyphen_232(self) -> None:
+        art = {"model": {"type": "BR-232 049", "number": None}}
+        self.assertEqual(m.propose_split(art), ("br_hyphen_nn", "232", "049"))
+
+    def test_1116_railjet_typographic_quotes(self) -> None:
+        art = {"model": {"type": "1116 238-7 \u201eRailjet\u201c", "number": None}}
+        self.assertEqual(m.propose_split(art), ("series_4_3dash_tail", "1116", "238-7"))
+
+    def test_193_deutschlandpiercer_typographic_quotes(self) -> None:
+        art = {
+            "model": {
+                "type": "193 459-5 \u201eDeutschlandpiercer\u201c",
+                "number": None,
+            }
+        }
+        self.assertEqual(m.propose_split(art), ("series_3_3dash_tail", "193", "459-5"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Dieser PR ergänzt die Datenbank um die Roco-Herbstneuheiten 2025 und die passende Tag-Taxonomie.

**Inhalt**
- Neuer Tag `roco-herbstneuheiten-2025` inkl. `config/tags/roco-herbstneuheiten-2025.json`.
- 19 neue Artikel unter `articles/roco/` (Loks und Züge laut Katalog), jeweils mit diesem Tag und konsistentem `model.type` / `model.number` wo der Autofix greift (u. a. 1116 …, 193 … Deutschlandpiercer, BR-232 049).

**Technik**
- `autofix_model_type_number_split.py`: Regeln `br_hyphen_nn`, `series_4_3dash_tail`, `series_3_3dash_tail`; zugehörige Unit-Tests.

`npm run validate:data` ist lokal grün.

Made with [Cursor](https://cursor.com)