### PR TITLE
fix(roco): PR #9-only articles use roco-neuheiten-2025 tag

### DIFF
--- a/articles/roco/70073.json
+++ b/articles/roco/70073.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/70073-diesellokomotive-2143-010-3-obb.html",

--- a/articles/roco/70074.json
+++ b/articles/roco/70074.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/70074-diesellokomotive-2143-010-3-obb.html",

--- a/articles/roco/70111.json
+++ b/articles/roco/70111.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/70111-dampflokomotive-ty2-pkp.html",

--- a/articles/roco/70112.json
+++ b/articles/roco/70112.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/70112-dampflokomotive-ty2-pkp.html",

--- a/articles/roco/70323.json
+++ b/articles/roco/70323.json
@@ -27,7 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/70323-elektrolokomotive-br-191-gts-rail.html",

--- a/articles/roco/70324.json
+++ b/articles/roco/70324.json
@@ -27,7 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/70324-elektrolokomotive-br-191-gts-rail.html",

--- a/articles/roco/70817.json
+++ b/articles/roco/70817.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/70817-diesellokomotive-108-001-9-dr.html",

--- a/articles/roco/70818.json
+++ b/articles/roco/70818.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/70818-diesellokomotive-108-001-9-dr.html",

--- a/articles/roco/7100008.json
+++ b/articles/roco/7100008.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100008-dampflokomotive-95-0045-5-dr.html",

--- a/articles/roco/7100013.json
+++ b/articles/roco/7100013.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100013-dampflokomotive-31001-kwste.html",

--- a/articles/roco/7100014.json
+++ b/articles/roco/7100014.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100014-dampflokomotive-br-8970%e2%80%9375-db.html",

--- a/articles/roco/7100015.json
+++ b/articles/roco/7100015.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100015-dampflokomotive-10-001-db.html",

--- a/articles/roco/7100016.json
+++ b/articles/roco/7100016.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100016-dampflokomotive-50685-obb.html",

--- a/articles/roco/7100017.json
+++ b/articles/roco/7100017.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100017-dampflokomotive-01-0529-6-dr.html",

--- a/articles/roco/7100018.json
+++ b/articles/roco/7100018.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100018-dampflokomotive-br-043-db.html",

--- a/articles/roco/7100019.json
+++ b/articles/roco/7100019.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100019-dampflokomotive-086-407-4-db.html",

--- a/articles/roco/7100023.json
+++ b/articles/roco/7100023.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100023-dampflokomotive-br-3510-dr.html",

--- a/articles/roco/7100025.json
+++ b/articles/roco/7100025.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100025-dampflokomotive-302608-mav.html",

--- a/articles/roco/7100026.json
+++ b/articles/roco/7100026.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100026-dampflokomotive-rh-3541-csd.html",

--- a/articles/roco/7100027.json
+++ b/articles/roco/7100027.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100027-dampflokomotive-86-1617-9-dr.html",

--- a/articles/roco/7100029.json
+++ b/articles/roco/7100029.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7100029-dampflokomotive-23-076-vsm.html",

--- a/articles/roco/7110008.json
+++ b/articles/roco/7110008.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110008-dampflokomotive-95-0045-5-dr.html",

--- a/articles/roco/7110013.json
+++ b/articles/roco/7110013.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110013-dampflokomotive-31001-kwste.html",

--- a/articles/roco/7110014.json
+++ b/articles/roco/7110014.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110014-dampflokomotive-8970%e2%80%9375-db.html",

--- a/articles/roco/7110015.json
+++ b/articles/roco/7110015.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110015-dampflokomotive-10-001-db.html",

--- a/articles/roco/7110016.json
+++ b/articles/roco/7110016.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110016-dampflokomotive-50685-obb.html",

--- a/articles/roco/7110017.json
+++ b/articles/roco/7110017.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110017-dampflokomotive-01-0529-6-dr.html",

--- a/articles/roco/7110018.json
+++ b/articles/roco/7110018.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110018-dampflokomotive-br-043-db.html",

--- a/articles/roco/7110019.json
+++ b/articles/roco/7110019.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110019-dampflokomotive-086-407-4-db.html",

--- a/articles/roco/7110023.json
+++ b/articles/roco/7110023.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110023-dampflokomotive-br-3510-dr.html",

--- a/articles/roco/7110025.json
+++ b/articles/roco/7110025.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110025-dampflokomotive-302608-mav.html",

--- a/articles/roco/7110026.json
+++ b/articles/roco/7110026.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110026-dampflokomotive-rh-3541-csd.html",

--- a/articles/roco/7110027.json
+++ b/articles/roco/7110027.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110027-dampflokomotive-86-1617-9-dr.html",

--- a/articles/roco/7110029.json
+++ b/articles/roco/7110029.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7110029-dampflokomotive-23-076-vsm.html",

--- a/articles/roco/7120008.json
+++ b/articles/roco/7120008.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120008-dampflokomotive-95-0045-5-dr.html",

--- a/articles/roco/7120013.json
+++ b/articles/roco/7120013.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120013-dampflokomotive-31001-kwste.html",

--- a/articles/roco/7120015.json
+++ b/articles/roco/7120015.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120015-dampflokomotive-10-001-db.html",

--- a/articles/roco/7120016.json
+++ b/articles/roco/7120016.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120016-dampflokomotive-50685-obb.html",

--- a/articles/roco/7120017.json
+++ b/articles/roco/7120017.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120017-dampflokomotive-01-0529-6-dr.html",

--- a/articles/roco/7120018.json
+++ b/articles/roco/7120018.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120018-dampflokomotive-br-043-db.html",

--- a/articles/roco/7120019.json
+++ b/articles/roco/7120019.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120019-dampflokomotive-086-407-4-db.html",

--- a/articles/roco/7120023.json
+++ b/articles/roco/7120023.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120023-dampflokomotive-br-3510-dr.html",

--- a/articles/roco/7120027.json
+++ b/articles/roco/7120027.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/7120027-dampflokomotive-86-1617-9-dr.html",

--- a/articles/roco/71383.json
+++ b/articles/roco/71383.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71383-dampflokomotive-ok1-360-pkp.html",

--- a/articles/roco/71384.json
+++ b/articles/roco/71384.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71384-dampflokomotive-ok1-360-pkp.html",

--- a/articles/roco/71387.json
+++ b/articles/roco/71387.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71387-dampflokomotive-38-3553-db.html",

--- a/articles/roco/71388.json
+++ b/articles/roco/71388.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71388-dampflokomotive-38-3553-db.html",

--- a/articles/roco/71397.json
+++ b/articles/roco/71397.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71397-dampflokomotive-38-2833-dr.html",

--- a/articles/roco/71398.json
+++ b/articles/roco/71398.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/71398-dampflokomotive-38-2833-dr.html",

--- a/articles/roco/71416.json
+++ b/articles/roco/71416.json
@@ -27,7 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/71416-elektrolokomotive-re-420-257-8-sbb-cargo.html",

--- a/articles/roco/71417.json
+++ b/articles/roco/71417.json
@@ -27,7 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/71417-elektrolokomotive-re-420-257-8-sbb-cargo.html",

--- a/articles/roco/7300006.json
+++ b/articles/roco/7300006.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300006-diesellokomotive-bb-62405-sncf.html",

--- a/articles/roco/7300012.json
+++ b/articles/roco/7300012.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300012-diesellokomotive-t-6690107-csd.html",

--- a/articles/roco/7300041.json
+++ b/articles/roco/7300041.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300041-diesellokomotive-218-445-5-db.html",

--- a/articles/roco/7300054.json
+++ b/articles/roco/7300054.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300054-diesellokomotive-749-218-4-cd.html",

--- a/articles/roco/7300056.json
+++ b/articles/roco/7300056.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300056-diesellokomotive-750-183-6-zssk.html",

--- a/articles/roco/7300057.json
+++ b/articles/roco/7300057.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300057-diesellokomotive-m62-221-mav.html",

--- a/articles/roco/7300058.json
+++ b/articles/roco/7300058.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/7300058-diesellokomotive-v-300-005-sbw.html",

--- a/articles/roco/78074.json
+++ b/articles/roco/78074.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/78074-diesellokomotive-2143-010-3-obb.html",

--- a/articles/roco/78078.json
+++ b/articles/roco/78078.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/78078-dampflokomotive-7714-obb.html",

--- a/articles/roco/78112.json
+++ b/articles/roco/78112.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/78112-dampflokomotive-ty2-pkp.html",

--- a/articles/roco/78818.json
+++ b/articles/roco/78818.json
@@ -27,7 +27,7 @@
     "diesellokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/diesellokomotiven/78818-diesellokomotive-108-001-9-dr.html",

--- a/articles/roco/79384.json
+++ b/articles/roco/79384.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/79384-dampflokomotive-ok1-360-pkp.html",

--- a/articles/roco/79388.json
+++ b/articles/roco/79388.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/79388-dampflokomotive-38-3553-db.html",

--- a/articles/roco/79398.json
+++ b/articles/roco/79398.json
@@ -27,7 +27,7 @@
     "dampflokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/dampflokomotiven/79398-dampflokomotive-38-2833-dr.html",

--- a/articles/roco/79417.json
+++ b/articles/roco/79417.json
@@ -27,7 +27,7 @@
     "elektrolokomotive"
   ],
   "tags": [
-    "roco-herbstneuheiten-2025"
+    "roco-neuheiten-2025"
   ],
   "source": {
     "url": "https://www.roco.cc/rde/produkte/lokomotiven/elektrolokomotiven/79417-elektrolokomotive-re-420-257-8-sbb-cargo.html",

--- a/config/tags/roco-neuheiten-2025.json
+++ b/config/tags/roco-neuheiten-2025.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": "1.0.0",
+  "name": "Roco Neuheiten 2025",
+  "slug": "roco-neuheiten-2025",
+  "description": "Artikel aus dem Roco-Neuheitenkatalog 2025."
+}


### PR DESCRIPTION
PR #9 (UVP Neuheiten 2025) had wrongly tagged PR9-only imports as roco-herbstneuheiten-2025. Replace with roco-neuheiten-2025 on paths touched only by #9, not the 19-file overlap with PR #8 Herbstneuheiten.

Add config/tags/roco-neuheiten-2025.json for the new slug.

## Zusammenfassung

Kurz beschreiben, was ergänzt oder korrigiert wurde.

## Checkliste

- [x] Schema eingehalten.
- [x] Pflichtfelder ausgefüllt.
- [x] Quelle (`source.url`) gesetzt oder im PR begründet.
- [x] Lokal `npm run check` ausgeführt.
- [x] CI **Validate Data** ist grün.
- [x] Freitext auf Deutsch, sofern zutreffend.

## Hinweis

Bei KI-Unterstützung: kurz erwähnen, wie Inhalte verifiziert wurden.
