### PR TITLE
PIKO Neuheiten 2026: Kampagnen-Tag und Erscheinungsjahr

### DIFF
--- a/articles/piko/21004.json
+++ b/articles/piko/21004.json
@@ -3,7 +3,7 @@
   "id": "piko-21004",
   "manufacturer": "PIKO",
   "articleNumber": "21004",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 184.1 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21004\nEAN: 4015615210047\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56644\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-184.1-db-iv-49192.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21005.json
+++ b/articles/piko/21005.json
@@ -3,7 +3,7 @@
   "id": "piko-21005",
   "manufacturer": "PIKO",
   "articleNumber": "21005",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 184.1 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21005\nEAN: 4015615210054\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-184.1-db-iv,-inkl.-piko-sound-decoder-49193.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21006.json
+++ b/articles/piko/21006.json
@@ -3,7 +3,7 @@
   "id": "piko-21006",
   "manufacturer": "PIKO",
   "articleNumber": "21006",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 184.1 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21006\nEAN: 4015615210061\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-184.1-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49195.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21007.json
+++ b/articles/piko/21007.json
@@ -3,7 +3,7 @@
   "id": "piko-21007",
   "manufacturer": "PIKO",
   "articleNumber": "21007",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 184.0 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21007\nEAN: 4015615210078\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56644\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-184.0-db-iv-49196.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21008.json
+++ b/articles/piko/21008.json
@@ -3,7 +3,7 @@
   "id": "piko-21008",
   "manufacturer": "PIKO",
   "articleNumber": "21008",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 184.0 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21008\nEAN: 4015615210085\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-184.0-db-iv,-inkl.-piko-sound-decoder-49197.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21009.json
+++ b/articles/piko/21009.json
@@ -3,7 +3,7 @@
   "id": "piko-21009",
   "manufacturer": "PIKO",
   "articleNumber": "21009",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 184.0 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21009\nEAN: 4015615210092\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-184.0-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49194.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21024.json
+++ b/articles/piko/21024.json
@@ -3,7 +3,7 @@
   "id": "piko-21024",
   "manufacturer": "PIKO",
   "articleNumber": "21024",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok E669.1 CSD IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21024\nEAN: 4015615210245\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 216\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56645\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-e669.1-csd-iv-49255.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21025.json
+++ b/articles/piko/21025.json
@@ -3,7 +3,7 @@
   "id": "piko-21025",
   "manufacturer": "PIKO",
   "articleNumber": "21025",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok E669.1 CSD IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21025\nEAN: 4015615210252\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 216\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-e669.1-csd-iv,-inkl.-piko-sound-decoder-49256.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21027.json
+++ b/articles/piko/21027.json
@@ -3,7 +3,7 @@
   "id": "piko-21027",
   "manufacturer": "PIKO",
   "articleNumber": "21027",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 181 CD V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21027\nEAN: 4015615210276\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 216\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56645\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-181-cd-v-49257.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21028.json
+++ b/articles/piko/21028.json
@@ -3,7 +3,7 @@
   "id": "piko-21028",
   "manufacturer": "PIKO",
   "articleNumber": "21028",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 181 CD V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21028\nEAN: 4015615210283\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 216\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-181-cd-v,-inkl.-piko-sound-decoder-49258.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21029.json
+++ b/articles/piko/21029.json
@@ -3,7 +3,7 @@
   "id": "piko-21029",
   "manufacturer": "PIKO",
   "articleNumber": "21029",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 181 STK VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21029\nEAN: 4015615210290\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 216\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56645\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-181-stk-vi-49764.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21030.json
+++ b/articles/piko/21030.json
@@ -3,7 +3,7 @@
   "id": "piko-21030",
   "manufacturer": "PIKO",
   "articleNumber": "21030",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok 181 STK VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21030\nEAN: 4015615210306\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 216\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-181-stk-vi,-inkl.-piko-sound-decoder-49765.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21044.json
+++ b/articles/piko/21044.json
@@ -3,7 +3,7 @@
   "id": "piko-21044",
   "manufacturer": "PIKO",
   "articleNumber": "21044",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 239.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 1067 ÖBB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21044\nEAN: 4015615210443\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 121\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56649\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-1067-oebb-iv-49119.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21045.json
+++ b/articles/piko/21045.json
@@ -3,7 +3,7 @@
   "id": "piko-21045",
   "manufacturer": "PIKO",
   "articleNumber": "21045",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1067 ÖBB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21045\nEAN: 4015615210450\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 121\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1067-oebb-iv,-inkl.-piko-sound-decoder-49120.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21046.json
+++ b/articles/piko/21046.json
@@ -3,7 +3,7 @@
   "id": "piko-21046",
   "manufacturer": "PIKO",
   "articleNumber": "21046",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1067 ÖBB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21046\nEAN: 4015615210467\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 121\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1067-oebb-iv-wechselstromversion,-inkl.-piko-sound-decoder-49121.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21047.json
+++ b/articles/piko/21047.json
@@ -3,7 +3,7 @@
   "id": "piko-21047",
   "manufacturer": "PIKO",
   "articleNumber": "21047",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 239.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 1067 ÖBB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21047\nEAN: 4015615210474\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 121\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56649\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-1067-oebb-iii-49123.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21048.json
+++ b/articles/piko/21048.json
@@ -3,7 +3,7 @@
   "id": "piko-21048",
   "manufacturer": "PIKO",
   "articleNumber": "21048",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1067 ÖBB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21048\nEAN: 4015615210481\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 121\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1067-oebb-iii,-inkl.-piko-sound-decoder-49124.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21049.json
+++ b/articles/piko/21049.json
@@ -3,7 +3,7 @@
   "id": "piko-21049",
   "manufacturer": "PIKO",
   "articleNumber": "21049",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1067 ÖBB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21049\nEAN: 4015615210498\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 121\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1067-oebb-iii-wechselstromversion,-inkl.-piko-sound-decoder-49122.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21060.json
+++ b/articles/piko/21060.json
@@ -3,7 +3,7 @@
   "id": "piko-21060",
   "manufacturer": "PIKO",
   "articleNumber": "21060",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 239.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 119 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21060\nEAN: 4015615210603\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56660\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-119-db-iv-49591.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21062.json
+++ b/articles/piko/21062.json
@@ -3,7 +3,7 @@
   "id": "piko-21062",
   "manufacturer": "PIKO",
   "articleNumber": "21062",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 119 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21062\nEAN: 4015615210627\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-119-db-iv,-inkl.-piko-sound-decoder-49592.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21063.json
+++ b/articles/piko/21063.json
@@ -3,7 +3,7 @@
   "id": "piko-21063",
   "manufacturer": "PIKO",
   "articleNumber": "21063",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 119 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21063\nEAN: 4015615210634\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-119-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49593.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21080.json
+++ b/articles/piko/21080.json
@@ -3,7 +3,7 @@
   "id": "piko-21080",
   "manufacturer": "PIKO",
   "articleNumber": "21080",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 229.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 110 CSD IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21080\nEAN: 4015615210801\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56662\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-110-csd-iv-49579.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21082.json
+++ b/articles/piko/21082.json
@@ -3,7 +3,7 @@
   "id": "piko-21082",
   "manufacturer": "PIKO",
   "articleNumber": "21082",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 339.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 110 CSD IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21082\nEAN: 4015615210825\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-110-csd-iv,-inkl.-piko-sound-decoder-49580.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21083.json
+++ b/articles/piko/21083.json
@@ -3,7 +3,7 @@
   "id": "piko-21083",
   "manufacturer": "PIKO",
   "articleNumber": "21083",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 339.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 110 CSD IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21083\nEAN: 4015615210832\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-110-csd-iv-wechselstromversion,-inkl.-piko-sound-decoder-49581.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21084.json
+++ b/articles/piko/21084.json
@@ -3,7 +3,7 @@
   "id": "piko-21084",
   "manufacturer": "PIKO",
   "articleNumber": "21084",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 229.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 210 CD VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21084\nEAN: 4015615210849\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56662\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-210-cd-vi-49585.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21085.json
+++ b/articles/piko/21085.json
@@ -3,7 +3,7 @@
   "id": "piko-21085",
   "manufacturer": "PIKO",
   "articleNumber": "21085",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 339.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 210 CD VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21085\nEAN: 4015615210856\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-210-cd-vi,-inkl.-piko-sound-decoder-49586.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21086.json
+++ b/articles/piko/21086.json
@@ -3,7 +3,7 @@
   "id": "piko-21086",
   "manufacturer": "PIKO",
   "articleNumber": "21086",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 339.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 210 CD VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21086\nEAN: 4015615210863\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-210-cd-vi-wechselstromversion,-inkl.-piko-sound-decoder-49587.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21704.json
+++ b/articles/piko/21704.json
@@ -3,7 +3,7 @@
   "id": "piko-21704",
   "manufacturer": "PIKO",
   "articleNumber": "21704",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 223.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 151 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21704\nEAN: 4015615217046\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56523\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung und Anfahrlampen\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-151-db-iv-46023.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21705.json
+++ b/articles/piko/21705.json
@@ -3,7 +3,7 @@
   "id": "piko-21705",
   "manufacturer": "PIKO",
   "articleNumber": "21705",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 151 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21705\nEAN: 4015615217053\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung und Anfahrlampen\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-151-db-iv,-inkl.-piko-sound-decoder-46024.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21706.json
+++ b/articles/piko/21706.json
@@ -3,7 +3,7 @@
   "id": "piko-21706",
   "manufacturer": "PIKO",
   "articleNumber": "21706",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 151 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21706\nEAN: 4015615217060\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung und Anfahrlampen\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-151-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-46025.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21710.json
+++ b/articles/piko/21710.json
@@ -3,7 +3,7 @@
   "id": "piko-21710",
   "manufacturer": "PIKO",
   "articleNumber": "21710",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 111 122 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21710\nEAN: 4015615217107\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56572\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-111-122-db-iv-45349.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21711.json
+++ b/articles/piko/21711.json
@@ -3,7 +3,7 @@
   "id": "piko-21711",
   "manufacturer": "PIKO",
   "articleNumber": "21711",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 315.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 111 122 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21711\nEAN: 4015615217114\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-111-122-db-iv,-inkl.-piko-sound-decoder-45350.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21712.json
+++ b/articles/piko/21712.json
@@ -3,7 +3,7 @@
   "id": "piko-21712",
   "manufacturer": "PIKO",
   "articleNumber": "21712",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 315.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 111 122 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21712\nEAN: 4015615217121\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-111-122-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-45351.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21722.json
+++ b/articles/piko/21722.json
@@ -3,7 +3,7 @@
   "id": "piko-21722",
   "manufacturer": "PIKO",
   "articleNumber": "21722",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 225.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 1041 ÖBB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21722\nEAN: 4015615217220\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56520\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-1041-oebb-iv-44770.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21723.json
+++ b/articles/piko/21723.json
@@ -3,7 +3,7 @@
   "id": "piko-21723",
   "manufacturer": "PIKO",
   "articleNumber": "21723",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 335.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1041 ÖBB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21723\nEAN: 4015615217237\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1041-oebb-iv,-inkl.-piko-sound-decoder-44771.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21724.json
+++ b/articles/piko/21724.json
@@ -3,7 +3,7 @@
   "id": "piko-21724",
   "manufacturer": "PIKO",
   "articleNumber": "21724",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 335.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1041 ÖBB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21724\nEAN: 4015615217244\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1041-oebb-iv-wechselstromversion,-inkl.-piko-sound-decoder-44772.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21737.json
+++ b/articles/piko/21737.json
@@ -3,7 +3,7 @@
   "id": "piko-21737",
   "manufacturer": "PIKO",
   "articleNumber": "21737",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 275.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 230 Cargo CD VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21737\nEAN: 4015615217374\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56586\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-230-cargo-cd-vi-45709.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21738.json
+++ b/articles/piko/21738.json
@@ -3,7 +3,7 @@
   "id": "piko-21738",
   "manufacturer": "PIKO",
   "articleNumber": "21738",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 385.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 230 CD Cargo VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21738\nEAN: 4015615217381\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-230-cd-cargo-vi,-inkl.-piko-sound-decoder-45710.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21739.json
+++ b/articles/piko/21739.json
@@ -3,7 +3,7 @@
   "id": "piko-21739",
   "manufacturer": "PIKO",
   "articleNumber": "21739",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 385.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 230 CD Cargo VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21739\nEAN: 4015615217398\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-230-cd-cargo-vi-wechselstromversion,-inkl.-piko-sound-decoder-45712.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21743.json
+++ b/articles/piko/21743.json
@@ -3,7 +3,7 @@
   "id": "piko-21743",
   "manufacturer": "PIKO",
   "articleNumber": "21743",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 275.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 240 CD Cargo VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21743\nEAN: 4015615217435\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56586\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-240-cd-cargo-vi-45724.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21744.json
+++ b/articles/piko/21744.json
@@ -3,7 +3,7 @@
   "id": "piko-21744",
   "manufacturer": "PIKO",
   "articleNumber": "21744",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 385.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 240 CD Cargo VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21744\nEAN: 4015615217442\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-240-cd-cargo-vi,-inkl.-piko-sound-decoder-45727.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21745.json
+++ b/articles/piko/21745.json
@@ -3,7 +3,7 @@
   "id": "piko-21745",
   "manufacturer": "PIKO",
   "articleNumber": "21745",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 385.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 240 CD Cargo VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21745\nEAN: 4015615217459\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-240-cd-cargo-vi-wechselstromversion,-inkl.-piko-sound-decoder-45729.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21746.json
+++ b/articles/piko/21746.json
@@ -3,7 +3,7 @@
   "id": "piko-21746",
   "manufacturer": "PIKO",
   "articleNumber": "21746",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 225.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Elektrolok BR 383 PKP Cargo International VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21746\nEAN: 4015615217466\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56544\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/elektrolok-br-383-pkp-cargo-international-vi-45947.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21747.json
+++ b/articles/piko/21747.json
@@ -3,7 +3,7 @@
   "id": "piko-21747",
   "manufacturer": "PIKO",
   "articleNumber": "21747",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Elektrolok BR 383 PKP Cargo International VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21747\nEAN: 4015615217473\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-elektrolok-br-383-pkp-cargo-international-vi,-inkl.-piko-sound-decoder-45948.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21748.json
+++ b/articles/piko/21748.json
@@ -3,7 +3,7 @@
   "id": "piko-21748",
   "manufacturer": "PIKO",
   "articleNumber": "21748",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Elektrolok BR 383 PKP Cargo International VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21748\nEAN: 4015615217480\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-elektrolok-br-383-pkp-cargo-international-vi-wechselstromversion,-inkl.-piko-sound-decoder-45949.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21749.json
+++ b/articles/piko/21749.json
@@ -3,7 +3,7 @@
   "id": "piko-21749",
   "manufacturer": "PIKO",
   "articleNumber": "21749",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Zweikraftlok \"dual mode\" BR 3193 Stern Hafferl VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21749\nEAN: 4015615217497\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56631\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/zweikraftlok-dual-mode-br-3193-stern-hafferl-vi-45730.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21750.json
+++ b/articles/piko/21750.json
@@ -3,7 +3,7 @@
   "id": "piko-21750",
   "manufacturer": "PIKO",
   "articleNumber": "21750",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Zweikraftlok \"dual mode\" BR 3193 Stern Hafferl VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21750\nEAN: 4015615217503\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-3193-stern-hafferl-vi,-inkl.-piko-sound-decoder-45731.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21751.json
+++ b/articles/piko/21751.json
@@ -3,7 +3,7 @@
   "id": "piko-21751",
   "manufacturer": "PIKO",
   "articleNumber": "21751",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Zweikraftlok \"dual mode\" BR 3193 Stern Hafferl VI Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21751\nEAN: 4015615217510\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-3193-stern-hafferl-vi-wechselstrom,-inkl.-piko-sound-decoder-45732.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21773.json
+++ b/articles/piko/21773.json
@@ -3,7 +3,7 @@
   "id": "piko-21773",
   "manufacturer": "PIKO",
   "articleNumber": "21773",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 219.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 110 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21773\nEAN: 4015615217732\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 190\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56549\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-110-db-iv-49027.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21774.json
+++ b/articles/piko/21774.json
@@ -3,7 +3,7 @@
   "id": "piko-21774",
   "manufacturer": "PIKO",
   "articleNumber": "21774",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 329.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 110 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21774\nEAN: 4015615217749\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 190\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-110-db-iv,-inkl.-piko-sound-decoder-49028.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21775.json
+++ b/articles/piko/21775.json
@@ -3,7 +3,7 @@
   "id": "piko-21775",
   "manufacturer": "PIKO",
   "articleNumber": "21775",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 329.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 110 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21775\nEAN: 4015615217756\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 190\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-110-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49029.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21776.json
+++ b/articles/piko/21776.json
@@ -3,7 +3,7 @@
   "id": "piko-21776",
   "manufacturer": "PIKO",
   "articleNumber": "21776",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 219.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 110.3 DB AG V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21776\nEAN: 4015615217763\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56571\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-110.3-db-ag-v-49080.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21777.json
+++ b/articles/piko/21777.json
@@ -3,7 +3,7 @@
   "id": "piko-21777",
   "manufacturer": "PIKO",
   "articleNumber": "21777",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 329.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 110.3 DB AG V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21777\nEAN: 4015615217770\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-110.3-db-ag-v,-inkl.-piko-sound-decoder-49081.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21778.json
+++ b/articles/piko/21778.json
@@ -3,7 +3,7 @@
   "id": "piko-21778",
   "manufacturer": "PIKO",
   "articleNumber": "21778",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 329.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 110.3 DB AG V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21778\nEAN: 4015615217787\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-110.3-db-ag-v-wechselstromversion,-inkl.-piko-sound-decoder-49082.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21779.json
+++ b/articles/piko/21779.json
@@ -3,7 +3,7 @@
   "id": "piko-21779",
   "manufacturer": "PIKO",
   "articleNumber": "21779",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 219.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 114 DB AG VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21779\nEAN: 4015615217794\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56558\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-114-db-ag-vi-49083.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21780.json
+++ b/articles/piko/21780.json
@@ -3,7 +3,7 @@
   "id": "piko-21780",
   "manufacturer": "PIKO",
   "articleNumber": "21780",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 334.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 114 DB AG VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21780\nEAN: 4015615217800\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-114-db-ag-vi,-inkl.-piko-sound-decoder-49084.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21781.json
+++ b/articles/piko/21781.json
@@ -3,7 +3,7 @@
   "id": "piko-21781",
   "manufacturer": "PIKO",
   "articleNumber": "21781",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 334.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 114 DB AG VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21781\nEAN: 4015615217817\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-114-db-ag-vi-wechselstromversion,-inkl.-piko-sound-decoder-49085.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21788.json
+++ b/articles/piko/21788.json
@@ -3,7 +3,7 @@
   "id": "piko-21788",
   "manufacturer": "PIKO",
   "articleNumber": "21788",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 219.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 139 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21788\nEAN: 4015615217886\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 190\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56549\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-139-db-iv-49125.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21789.json
+++ b/articles/piko/21789.json
@@ -3,7 +3,7 @@
   "id": "piko-21789",
   "manufacturer": "PIKO",
   "articleNumber": "21789",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 329.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 139 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21789\nEAN: 4015615217893\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 190\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-139-db-iv,-inkl.-piko-sound-decoder-49126.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21790.json
+++ b/articles/piko/21790.json
@@ -3,7 +3,7 @@
   "id": "piko-21790",
   "manufacturer": "PIKO",
   "articleNumber": "21790",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 329.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 139 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21790\nEAN: 4015615217909\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 190\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-139-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49127.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21791.json
+++ b/articles/piko/21791.json
@@ -3,7 +3,7 @@
   "id": "piko-21791",
   "manufacturer": "PIKO",
   "articleNumber": "21791",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 219.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 243 019 WFL VI, S-Bahn Leipzig Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21791\nEAN: 4015615217916\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56558\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-243-019-wfl-vi,-s-bahn-leipzig-49280.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21792.json
+++ b/articles/piko/21792.json
@@ -3,7 +3,7 @@
   "id": "piko-21792",
   "manufacturer": "PIKO",
   "articleNumber": "21792",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 334.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok 243 019 WFL VI, S-Bahn Leipzig, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21792\nEAN: 4015615217923\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-243-019-wfl-vi,-s-bahn-leipzig,-inkl.-piko-sound-decoder-49288.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21793.json
+++ b/articles/piko/21793.json
@@ -3,7 +3,7 @@
   "id": "piko-21793",
   "manufacturer": "PIKO",
   "articleNumber": "21793",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 334.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok 243 019 WFL VI, S-Bahn Leipzig Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21793\nEAN: 4015615217930\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-243-019-wfl-vi,-s-bahn-leipzig-wechselstromversion,-inkl.-piko-sound-decoder-49294.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21797.json
+++ b/articles/piko/21797.json
@@ -3,7 +3,7 @@
   "id": "piko-21797",
   "manufacturer": "PIKO",
   "articleNumber": "21797",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 187 SNCB VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21797\nEAN: 4015615217978\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: SNCB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56545\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-187-sncb-vi-49198.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21798.json
+++ b/articles/piko/21798.json
@@ -3,7 +3,7 @@
   "id": "piko-21798",
   "manufacturer": "PIKO",
   "articleNumber": "21798",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 187 SNCB VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21798\nEAN: 4015615217985\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SNCB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-187-sncb-vi,-inkl.-piko-sound-decoder-49199.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21799.json
+++ b/articles/piko/21799.json
@@ -3,7 +3,7 @@
   "id": "piko-21799",
   "manufacturer": "PIKO",
   "articleNumber": "21799",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 187 SNCB VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21799\nEAN: 4015615217992\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: SNCB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-187-sncb-vi-wechselstromversion,-inkl.-piko-sound-decoder-49200.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21803.json
+++ b/articles/piko/21803.json
@@ -3,7 +3,7 @@
   "id": "piko-21803",
   "manufacturer": "PIKO",
   "articleNumber": "21803",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 225.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Elektrolok Vectron BR 193 Baltic PKP IC VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21803\nEAN: 4015615218036\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56544\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/elektrolok-vectron-br-193-baltic-pkp-ic-vi-49201.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21804.json
+++ b/articles/piko/21804.json
@@ -3,7 +3,7 @@
   "id": "piko-21804",
   "manufacturer": "PIKO",
   "articleNumber": "21804",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Elektrolok Vectron BR 193 Baltic PKP IC VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21804\nEAN: 4015615218043\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-elektrolok-vectron-br-193-baltic-pkp-ic-vi,-inkl.-piko-sound-decoder-49202.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21809.json
+++ b/articles/piko/21809.json
@@ -3,7 +3,7 @@
   "id": "piko-21809",
   "manufacturer": "PIKO",
   "articleNumber": "21809",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 235.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 1110.0 ÖBB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21809\nEAN: 4015615218098\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 205\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56563\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-1110.0-oebb-iv-49485.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21810.json
+++ b/articles/piko/21810.json
@@ -3,7 +3,7 @@
   "id": "piko-21810",
   "manufacturer": "PIKO",
   "articleNumber": "21810",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1110.0 ÖBB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21810\nEAN: 4015615218104\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 205\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1110.0-oebb-iv,-inkl.-piko-sound-decoder-49496.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21811.json
+++ b/articles/piko/21811.json
@@ -3,7 +3,7 @@
   "id": "piko-21811",
   "manufacturer": "PIKO",
   "articleNumber": "21811",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1110.0 ÖBB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21811\nEAN: 4015615218111\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 205\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1110.0-oebb-iv-wechselstromversion,-inkl.-piko-sound-decoder-49497.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21824.json
+++ b/articles/piko/21824.json
@@ -3,7 +3,7 @@
   "id": "piko-21824",
   "manufacturer": "PIKO",
   "articleNumber": "21824",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Elektrotriebzug BR442 \"Talent 2\" S-Bahn Rostock DB AG VI 5tlg. Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21824\nEAN: 4015615218241\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 1002\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\n(Innen-)Beleuchtung: Werkseitig nicht für Innenbeleuchtung vorbereitet\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56614\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/elektrotriebzug-br442-talent-2-s-bahn-rostock-db-ag-vi-5tlg.-48967.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21825.json
+++ b/articles/piko/21825.json
@@ -3,7 +3,7 @@
   "id": "piko-21825",
   "manufacturer": "PIKO",
   "articleNumber": "21825",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 419.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Elektrotriebzug BR442 \"Talent 2\" S-Bahn Rostock DB AG VI 5tlg., inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21825\nEAN: 4015615218258\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 1002\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Werkseitig nicht für Innenbeleuchtung vorbereitet\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-elektrotriebzug-br442-talent-2-s-bahn-rostock-db-ag-vi-5tlg.,-inkl.-piko-sound-decoder-48990.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21826.json
+++ b/articles/piko/21826.json
@@ -3,7 +3,7 @@
   "id": "piko-21826",
   "manufacturer": "PIKO",
   "articleNumber": "21826",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 419.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Elektrotriebzug BR442 \"Talent 2\" S-Bahn Rostock VI 5tlg Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21826\nEAN: 4015615218265\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 1002\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Werkseitig nicht für Innenbeleuchtung vorbereitet\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-elektrotriebzug-br442-talent-2-s-bahn-rostock-vi-5tlg-wechselstrom,-inkl.-piko-sound-decoder-48991.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21830.json
+++ b/articles/piko/21830.json
@@ -3,7 +3,7 @@
   "id": "piko-21830",
   "manufacturer": "PIKO",
   "articleNumber": "21830",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 225.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Elektrolok Vectron BR 7193 Medway VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21830\nEAN: 4015615218302\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56544\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/elektrolok-vectron-br-7193-medway-vi-49412.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21831.json
+++ b/articles/piko/21831.json
@@ -3,7 +3,7 @@
   "id": "piko-21831",
   "manufacturer": "PIKO",
   "articleNumber": "21831",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Elektrolok Vectron BR 7193 Medway VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21831\nEAN: 4015615218319\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-elektrolok-vectron-br-7193-medway-vi,-inkl.-piko-sound-decoder-49413.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21832.json
+++ b/articles/piko/21832.json
@@ -3,7 +3,7 @@
   "id": "piko-21832",
   "manufacturer": "PIKO",
   "articleNumber": "21832",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Elektrolok Vectron BR 7193 Medway VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21832\nEAN: 4015615218326\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-elektrolok-vectron-br-7193-medway-vi-wechselstromversion,-inkl.-piko-sound-decoder-49414.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21839.json
+++ b/articles/piko/21839.json
@@ -3,7 +3,7 @@
   "id": "piko-21839",
   "manufacturer": "PIKO",
   "articleNumber": "21839",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Zweikraftlok \"dual mode\" BR 248 SETG VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21839\nEAN: 4015615218395\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56631\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/zweikraftlok-dual-mode-br-248-setg-vi-49186.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21840.json
+++ b/articles/piko/21840.json
@@ -3,7 +3,7 @@
   "id": "piko-21840",
   "manufacturer": "PIKO",
   "articleNumber": "21840",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Zweikraftlok \"dual mode\" BR 248 SETG VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21840\nEAN: 4015615218401\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-setg-vi,-inkl.-piko-sound-decoder-49187.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/21841.json
+++ b/articles/piko/21841.json
@@ -3,7 +3,7 @@
   "id": "piko-21841",
   "manufacturer": "PIKO",
   "articleNumber": "21841",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Zweikraftlok \"dual mode\" BR 248 SETG VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21841\nEAN: 4015615218418\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-setg-vi-wechselstromversion,-inkl.-piko-sound-decoder-49188.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22004.json
+++ b/articles/piko/22004.json
@@ -3,7 +3,7 @@
   "id": "piko-22004",
   "manufacturer": "PIKO",
   "articleNumber": "22004",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok Rh 500 NS IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22004\nEAN: 4015615220046\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar # 56642\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-rh-500-ns-iv-49112.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22005.json
+++ b/articles/piko/22005.json
@@ -3,7 +3,7 @@
   "id": "piko-22005",
   "manufacturer": "PIKO",
   "articleNumber": "22005",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Rh 500 NS IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22005\nEAN: 4015615220053\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56642\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rh-500-ns-iv,-inkl.-piko-sound-decoder-49114.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22006.json
+++ b/articles/piko/22006.json
@@ -3,7 +3,7 @@
   "id": "piko-22006",
   "manufacturer": "PIKO",
   "articleNumber": "22006",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Rh 500 NS IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22006\nEAN: 4015615220060\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rh-500-ns-iv-wechselstromversion,-inkl.-piko-sound-decoder-49115.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22007.json
+++ b/articles/piko/22007.json
@@ -3,7 +3,7 @@
   "id": "piko-22007",
   "manufacturer": "PIKO",
   "articleNumber": "22007",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok Rh 500 VSM VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22007\nEAN: 4015615220077\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar # 56642\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-rh-500-vsm-vi-49118.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22008.json
+++ b/articles/piko/22008.json
@@ -3,7 +3,7 @@
   "id": "piko-22008",
   "manufacturer": "PIKO",
   "articleNumber": "22008",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Rh 500 VSM VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22008\nEAN: 4015615220084\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56642\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rh-500-vsm-vi,-inkl.-piko-sound-decoder-49117.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22009.json
+++ b/articles/piko/22009.json
@@ -3,7 +3,7 @@
   "id": "piko-22009",
   "manufacturer": "PIKO",
   "articleNumber": "22009",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Rh 500 VSM VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22009\nEAN: 4015615220091\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rh-500-vsm-vi-wechselstromversion,-inkl.-piko-sound-decoder-49116.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22010.json
+++ b/articles/piko/22010.json
@@ -3,7 +3,7 @@
   "id": "piko-22010",
   "manufacturer": "PIKO",
   "articleNumber": "22010",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok Rangiertraktor Rh 600 DSB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22010\nEAN: 4015615220107\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DSB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar # 56642\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-rangiertraktor-rh-600-dsb-iii-49448.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22011.json
+++ b/articles/piko/22011.json
@@ -3,7 +3,7 @@
   "id": "piko-22011",
   "manufacturer": "PIKO",
   "articleNumber": "22011",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Rangiertraktor Rh 600 DSB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22011\nEAN: 4015615220114\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DSB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 1\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56642\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rangiertraktor-rh-600-dsb-iii,-inkl.-piko-sound-decoder-49451.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22012.json
+++ b/articles/piko/22012.json
@@ -3,7 +3,7 @@
   "id": "piko-22012",
   "manufacturer": "PIKO",
   "articleNumber": "22012",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Rangiertraktor Rh 600 DSB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22012\nEAN: 4015615220121\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DSB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 104\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 1\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rangiertraktor-rh-600-dsb-iii-wechselstromversion,-inkl.-piko-sound-decoder-49452.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22030.json
+++ b/articles/piko/22030.json
@@ -3,7 +3,7 @@
   "id": "piko-22030",
   "manufacturer": "PIKO",
   "articleNumber": "22030",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok D.445 1. Serie mit Logo FS V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22030\nEAN: 4015615220305\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-d.445-1.-serie-mit-logo-fs-v-49174.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22031.json
+++ b/articles/piko/22031.json
@@ -3,7 +3,7 @@
   "id": "piko-22031",
   "manufacturer": "PIKO",
   "articleNumber": "22031",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 399.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok D.445 1. Serie mit Logo FS V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22031\nEAN: 4015615220312\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-d.445-1.-serie-mit-logo-fs-v,-inkl.-piko-sound-decoder-49175.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22032.json
+++ b/articles/piko/22032.json
@@ -3,7 +3,7 @@
   "id": "piko-22032",
   "manufacturer": "PIKO",
   "articleNumber": "22032",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok D.445 2.Serie Navetta FS IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22032\nEAN: 4015615220329\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-d.445-2.serie-navetta-fs-iv-49176.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22033.json
+++ b/articles/piko/22033.json
@@ -3,7 +3,7 @@
   "id": "piko-22033",
   "manufacturer": "PIKO",
   "articleNumber": "22033",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 399.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok D.445 2. Serie Navetta FS IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22033\nEAN: 4015615220336\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-d.445-2.-serie-navetta-fs-iv,-inkl.-piko-sound-decoder-49177.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22034.json
+++ b/articles/piko/22034.json
@@ -3,7 +3,7 @@
   "id": "piko-22034",
   "manufacturer": "PIKO",
   "articleNumber": "22034",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok D.445 3.Serie mit Schneepflug FS VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22034\nEAN: 4015615220343\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-d.445-3.serie-mit-schneepflug-fs-vi-49178.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22035.json
+++ b/articles/piko/22035.json
@@ -3,7 +3,7 @@
   "id": "piko-22035",
   "manufacturer": "PIKO",
   "articleNumber": "22035",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 399.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok D.445 3. Serie mit Schneepflug FS VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22035\nEAN: 4015615220350\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-d.445-3.-serie-mit-schneepflug-fs-vi,-inkl.-piko-sound-decoder-49179.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22036.json
+++ b/articles/piko/22036.json
@@ -3,7 +3,7 @@
   "id": "piko-22036",
   "manufacturer": "PIKO",
   "articleNumber": "22036",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok D.445 1. Serie XMPR FS VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22036\nEAN: 4015615220367\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-d.445-1.-serie-xmpr-fs-vi-49180.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22037.json
+++ b/articles/piko/22037.json
@@ -3,7 +3,7 @@
   "id": "piko-22037",
   "manufacturer": "PIKO",
   "articleNumber": "22037",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 399.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok D.445 1. Serie XMPR FS VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22037\nEAN: 4015615220374\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 162\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-d.445-1.-serie-xmpr-fs-vi,-inkl.-piko-sound-decoder-49181.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22040.json
+++ b/articles/piko/22040.json
@@ -3,7 +3,7 @@
   "id": "piko-22040",
   "manufacturer": "PIKO",
   "articleNumber": "22040",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR V 90 DB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22040\nEAN: 4015615220404\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56655\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-v-90-db-iii-49567.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22042.json
+++ b/articles/piko/22042.json
@@ -3,7 +3,7 @@
   "id": "piko-22042",
   "manufacturer": "PIKO",
   "articleNumber": "22042",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR V 90 DB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22042\nEAN: 4015615220428\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-v-90-db-iii,-inkl.-piko-sound-decoder-49570.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22043.json
+++ b/articles/piko/22043.json
@@ -3,7 +3,7 @@
   "id": "piko-22043",
   "manufacturer": "PIKO",
   "articleNumber": "22043",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR V 90 DB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22043\nEAN: 4015615220435\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-v-90-db-iii-wechselstromversion,-inkl.-piko-sound-decoder-49571.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22044.json
+++ b/articles/piko/22044.json
@@ -3,7 +3,7 @@
   "id": "piko-22044",
   "manufacturer": "PIKO",
   "articleNumber": "22044",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 296 Railion VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22044\nEAN: 4015615220442\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56655\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-296-railion-vi-49572.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22045.json
+++ b/articles/piko/22045.json
@@ -3,7 +3,7 @@
   "id": "piko-22045",
   "manufacturer": "PIKO",
   "articleNumber": "22045",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 296 Railion VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22045\nEAN: 4015615220459\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-296-railion-vi,-inkl.-piko-sound-decoder-49574.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22046.json
+++ b/articles/piko/22046.json
@@ -3,7 +3,7 @@
   "id": "piko-22046",
   "manufacturer": "PIKO",
   "articleNumber": "22046",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 296 Railion VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22046\nEAN: 4015615220466\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 165\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-296-railion-vi-wechselstromversion,-inkl.-piko-sound-decoder-49575.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22060.json
+++ b/articles/piko/22060.json
@@ -3,7 +3,7 @@
   "id": "piko-22060",
   "manufacturer": "PIKO",
   "articleNumber": "22060",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 215 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22060\nEAN: 4015615220602\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56656\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-215-db-iv-49486.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22062.json
+++ b/articles/piko/22062.json
@@ -3,7 +3,7 @@
   "id": "piko-22062",
   "manufacturer": "PIKO",
   "articleNumber": "22062",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 215 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22062\nEAN: 4015615220626\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-215-db-iv,-inkl.-piko-sound-decoder-49487.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22063.json
+++ b/articles/piko/22063.json
@@ -3,7 +3,7 @@
   "id": "piko-22063",
   "manufacturer": "PIKO",
   "articleNumber": "22063",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 215 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22063\nEAN: 4015615220633\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-215-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49488.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22064.json
+++ b/articles/piko/22064.json
@@ -3,7 +3,7 @@
   "id": "piko-22064",
   "manufacturer": "PIKO",
   "articleNumber": "22064",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 199.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 215 DB AG V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22064\nEAN: 4015615220640\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56657\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-215-db-ag-v-49489.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22065.json
+++ b/articles/piko/22065.json
@@ -3,7 +3,7 @@
   "id": "piko-22065",
   "manufacturer": "PIKO",
   "articleNumber": "22065",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 215 DB AG V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22065\nEAN: 4015615220657\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-215-db-ag-v,-inkl.-piko-sound-decoder-49490.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22066.json
+++ b/articles/piko/22066.json
@@ -3,7 +3,7 @@
   "id": "piko-22066",
   "manufacturer": "PIKO",
   "articleNumber": "22066",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 309.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 215 DB AG V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22066\nEAN: 4015615220664\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-215-db-ag-v-wechselstromversion,-inkl.-piko-sound-decoder-49491.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22080.json
+++ b/articles/piko/22080.json
@@ -3,7 +3,7 @@
   "id": "piko-22080",
   "manufacturer": "PIKO",
   "articleNumber": "22080",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 249.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR MZ DSB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22080\nEAN: 4015615220800\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DSB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 241\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56659\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-mz-dsb-iv-49536.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/22082.json
+++ b/articles/piko/22082.json
@@ -3,7 +3,7 @@
   "id": "piko-22082",
   "manufacturer": "PIKO",
   "articleNumber": "22082",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 359.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR MZ DSB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 22082\nEAN: 4015615220824\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DSB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 241\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-mz-dsb-iv,-inkl.-piko-sound-decoder-49583.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/27509.json
+++ b/articles/piko/27509.json
@@ -3,7 +3,7 @@
   "id": "piko-27509",
   "manufacturer": "PIKO",
   "articleNumber": "27509",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 179.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dampflok G7.1 Rh7000 SNCB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27509\nEAN: 4015615275091\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: SNCB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder nachrüstbar #56629\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dampflok-g7.1-rh7000-sncb-iii-49569.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/27510.json
+++ b/articles/piko/27510.json
@@ -3,7 +3,7 @@
   "id": "piko-27510",
   "manufacturer": "PIKO",
   "articleNumber": "27510",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 293.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Schlepptenderlok G7.1 Rh7000 SNCB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27510\nEAN: 4015615275107\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SNCB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-g7.1-rh7000-sncb-iii,-inkl.-piko-sound-decoder-49573.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/27511.json
+++ b/articles/piko/27511.json
@@ -3,7 +3,7 @@
   "id": "piko-27511",
   "manufacturer": "PIKO",
   "articleNumber": "27511",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 293.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Schlepptenderlok G7.1 Rh7000 SNCB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27511\nEAN: 4015615275114\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: SNCB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-g7.1-rh7000-sncb-iii-wechselstromversion,-inkl.-piko-sound-decoder-49604.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/27512.json
+++ b/articles/piko/27512.json
@@ -3,7 +3,7 @@
   "id": "piko-27512",
   "manufacturer": "PIKO",
   "articleNumber": "27512",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 174.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Schlepptenderlok BR 55 (G7.1) Fotolack DRG II Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27512\nEAN: 4015615275121\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder nachrüstbar #56629\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/schlepptenderlok-br-55-g7.1-fotolack-drg-ii-48584.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/27513.json
+++ b/articles/piko/27513.json
@@ -3,7 +3,7 @@
   "id": "piko-27513",
   "manufacturer": "PIKO",
   "articleNumber": "27513",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 288.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Schlepptenderlok BR 55 (G7.1) Fotolack DRG II, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27513\nEAN: 4015615275138\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-br-55-g7.1-fotolack-drg-ii,-inkl.-piko-sound-decoder-48585.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/27514.json
+++ b/articles/piko/27514.json
@@ -3,7 +3,7 @@
   "id": "piko-27514",
   "manufacturer": "PIKO",
   "articleNumber": "27514",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 288.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Schlepptenderlok BR 55 (G7.1) Fotolack DRG II Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27514\nEAN: 4015615275145\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-br-55-g7.1-fotolack-drg-ii-wechselstromversion,-inkl.-piko-sound-decoder-48586.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/27518.json
+++ b/articles/piko/27518.json
@@ -3,7 +3,7 @@
   "id": "piko-27518",
   "manufacturer": "PIKO",
   "articleNumber": "27518",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 179.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Schlepptenderlok 431 (BR 55 / G7.1) MAV III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27518\nEAN: 4015615275183\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder nachrüstbar #56629\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/schlepptenderlok-431-br-55-g7.1-mav-iii-49191.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50708.json
+++ b/articles/piko/50708.json
@@ -3,7 +3,7 @@
   "id": "piko-50708",
   "manufacturer": "PIKO",
   "articleNumber": "50708",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 509.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok BR 62 DRG II, inkl. PIKO Sound-Decoder und Dampfgenerator Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50708\nEAN: 4015615507086\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 197\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung und Feuerbüchsenbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Dampffunktion werkseitig ausgerüstet",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-62-drg-ii,-inkl.-piko-sound-decoder-und-dampfgenerator-44683.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50711.json
+++ b/articles/piko/50711.json
@@ -3,7 +3,7 @@
   "id": "piko-50711",
   "manufacturer": "PIKO",
   "articleNumber": "50711",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 509.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok BR 62 DR IV, inkl. PIKO Sound-Decoder und Dampfgenerator Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50711\nEAN: 4015615507116\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 197\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung und Feuerbüchsenbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Dampffunktion werkseitig ausgerüstet",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-62-dr-iv,-inkl.-piko-sound-decoder-und-dampfgenerator-49282.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50712.json
+++ b/articles/piko/50712.json
@@ -3,7 +3,7 @@
   "id": "piko-50712",
   "manufacturer": "PIKO",
   "articleNumber": "50712",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 509.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok BR 62 DR IV Wechselstromversion, inkl. PIKO Sound-Decoder und Dampfgenerator Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50712\nEAN: 4015615507123\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DR\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 197\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung und Feuerbüchsenbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Dampffunktion werkseitig ausgerüstet",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-62-dr-iv-wechselstromversion,-inkl.-piko-sound-decoder-und-dampfgenerator-49283.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50740.json
+++ b/articles/piko/50740.json
@@ -3,7 +3,7 @@
   "id": "piko-50740",
   "manufacturer": "PIKO",
   "articleNumber": "50740",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 259.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dampflok Rh 691 ÖBB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50740\nEAN: 4015615507406\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder nachrüstbar # 56643\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dampflok-rh-691-oebb-iii-45693.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50741.json
+++ b/articles/piko/50741.json
@@ -3,7 +3,7 @@
   "id": "piko-50741",
   "manufacturer": "PIKO",
   "articleNumber": "50741",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok Rh 691 ÖBB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50741\nEAN: 4015615507413\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-rh-691-oebb-iii,-inkl.-piko-sound-decoder-45694.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50742.json
+++ b/articles/piko/50742.json
@@ -3,7 +3,7 @@
   "id": "piko-50742",
   "manufacturer": "PIKO",
   "articleNumber": "50742",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok Rh 691 ÖBB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50742\nEAN: 4015615507420\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-rh-691-oebb-iii-wechselstromversion,-inkl.-piko-sound-decoder-45695.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50743.json
+++ b/articles/piko/50743.json
@@ -3,7 +3,7 @@
   "id": "piko-50743",
   "manufacturer": "PIKO",
   "articleNumber": "50743",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 259.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dampflok BR 91 DRG II Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50743\nEAN: 4015615507437\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder nachrüstbar #56643\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dampflok-br-91-drg-ii-49206.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50744.json
+++ b/articles/piko/50744.json
@@ -3,7 +3,7 @@
   "id": "piko-50744",
   "manufacturer": "PIKO",
   "articleNumber": "50744",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok BR 91 DRG II, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50744\nEAN: 4015615507444\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-91-drg-ii,-inkl.-piko-sound-decoder-49207.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50745.json
+++ b/articles/piko/50745.json
@@ -3,7 +3,7 @@
   "id": "piko-50745",
   "manufacturer": "PIKO",
   "articleNumber": "50745",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok BR 91 DRG II Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50745\nEAN: 4015615507451\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-91-drg-ii-wechselstromversion,-inkl.-piko-sound-decoder-49208.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50746.json
+++ b/articles/piko/50746.json
@@ -3,7 +3,7 @@
   "id": "piko-50746",
   "manufacturer": "PIKO",
   "articleNumber": "50746",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 259.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dampflok Rh 75 ex BR 91 NS III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50746\nEAN: 4015615507468\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder nachrüstbar #56643\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dampflok-rh-75-ex-br-91-ns-iii-49601.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50747.json
+++ b/articles/piko/50747.json
@@ -3,7 +3,7 @@
   "id": "piko-50747",
   "manufacturer": "PIKO",
   "articleNumber": "50747",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok Rh 75 ex BR 91 NS III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50747\nEAN: 4015615507475\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-rh-75-ex-br-91-ns-iii,-inkl.-piko-sound-decoder-49602.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50748.json
+++ b/articles/piko/50748.json
@@ -3,7 +3,7 @@
   "id": "piko-50748",
   "manufacturer": "PIKO",
   "articleNumber": "50748",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok Rh 75 ex BR 91 NS III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50748\nEAN: 4015615507482\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-rh-75-ex-br-91-ns-iii-wechselstromversion,-inkl.-piko-sound-decoder-49599.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50749.json
+++ b/articles/piko/50749.json
@@ -3,7 +3,7 @@
   "id": "piko-50749",
   "manufacturer": "PIKO",
   "articleNumber": "50749",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 259.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dampflok BR 335.1 CSD III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50749\nEAN: 4015615507499\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder nachrüstbar #56643\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dampflok-br-335.1-csd-iii-49284.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50750.json
+++ b/articles/piko/50750.json
@@ -3,7 +3,7 @@
   "id": "piko-50750",
   "manufacturer": "PIKO",
   "articleNumber": "50750",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok BR 335.1 CSD III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50750\nEAN: 4015615507505\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-335.1-csd-iii,-inkl.-piko-sound-decoder-49285.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50765.json
+++ b/articles/piko/50765.json
@@ -3,7 +3,7 @@
   "id": "piko-50765",
   "manufacturer": "PIKO",
   "articleNumber": "50765",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 493.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok TKt48 PKP IV, inkl. PIKO Sound-Decoder und Dampfgenerator Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50765\nEAN: 4015615507659\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 163\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-tkt48-pkp-iv,-inkl.-piko-sound-decoder-und-dampfgenerator-49212.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50767.json
+++ b/articles/piko/50767.json
@@ -3,7 +3,7 @@
   "id": "piko-50767",
   "manufacturer": "PIKO",
   "articleNumber": "50767",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 493.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok TKt48 PKP III, inkl. PIKO Sound-Decoder und Dampfgenerator Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50767\nEAN: 4015615507673\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 163\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-tkt48-pkp-iii,-inkl.-piko-sound-decoder-und-dampfgenerator-49214.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/50802.json
+++ b/articles/piko/50802.json
@@ -3,7 +3,7 @@
   "id": "piko-50802",
   "manufacturer": "PIKO",
   "articleNumber": "50802",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 509.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dampflok Tr12 PKP III, inkl. PIKO Sound-Decoder und Dampfgenerator Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50802\nEAN: 4015615508021\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 200\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Dampffunktion werkseitig ausgerüstet\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-tr12-pkp-iii,-inkl.-piko-sound-decoder-und-dampfgenerator-49589.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51133.json
+++ b/articles/piko/51133.json
@@ -3,7 +3,7 @@
   "id": "piko-51133",
   "manufacturer": "PIKO",
   "articleNumber": "51133",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 229.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 152 Captrain VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51133\nEAN: 4015615511335\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 226\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56606\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-152-captrain-vi-49134.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51134.json
+++ b/articles/piko/51134.json
@@ -3,7 +3,7 @@
   "id": "piko-51134",
   "manufacturer": "PIKO",
   "articleNumber": "51134",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 152 Captrain VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51134\nEAN: 4015615511342\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 226\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-152-captrain-vi,-inkl.-piko-sound-decoder-49135.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51135.json
+++ b/articles/piko/51135.json
@@ -3,7 +3,7 @@
   "id": "piko-51135",
   "manufacturer": "PIKO",
   "articleNumber": "51135",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 152 Captrain VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51135\nEAN: 4015615511359\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 226\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-152-captrain-vi-wechselstromversion,-inkl.-piko-sound-decoder-49136.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51149.json
+++ b/articles/piko/51149.json
@@ -3,7 +3,7 @@
   "id": "piko-51149",
   "manufacturer": "PIKO",
   "articleNumber": "51149",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 259.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 1018 ÖBB V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51149\nEAN: 4015615511496\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 194\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56621\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-1018-oebb-v-44767.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51150.json
+++ b/articles/piko/51150.json
@@ -3,7 +3,7 @@
   "id": "piko-51150",
   "manufacturer": "PIKO",
   "articleNumber": "51150",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1018 ÖBB V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51150\nEAN: 4015615511502\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 194\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1018-oebb-v,-inkl.-piko-sound-decoder-44768.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51151.json
+++ b/articles/piko/51151.json
@@ -3,7 +3,7 @@
   "id": "piko-51151",
   "manufacturer": "PIKO",
   "articleNumber": "51151",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1018 ÖBB V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51151\nEAN: 4015615511519\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 194\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1018-oebb-v-wechselstromversion,-inkl.-piko-sound-decoder-44769.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51176.json
+++ b/articles/piko/51176.json
@@ -3,7 +3,7 @@
   "id": "piko-51176",
   "manufacturer": "PIKO",
   "articleNumber": "51176",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 225.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Zweikraftlok \"dual mode\" BR 248 Press VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51176\nEAN: 4015615511762\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56631\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/zweikraftlok-dual-mode-br-248-press-vi-45469.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51177.json
+++ b/articles/piko/51177.json
@@ -3,7 +3,7 @@
   "id": "piko-51177",
   "manufacturer": "PIKO",
   "articleNumber": "51177",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 335.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Zweikraftlok \"dual mode\" BR 248 Press VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51177\nEAN: 4015615511779\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-press-vi,-inkl.-piko-sound-decoder-45470.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51178.json
+++ b/articles/piko/51178.json
@@ -3,7 +3,7 @@
   "id": "piko-51178",
   "manufacturer": "PIKO",
   "articleNumber": "51178",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 335.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Zweikraftlok \"dual mode\" BR 248 Press VI Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51178\nEAN: 4015615511786\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-press-vi-wechselstrom,-inkl.-piko-sound-decoder-45471.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51193.json
+++ b/articles/piko/51193.json
@@ -3,7 +3,7 @@
   "id": "piko-51193",
   "manufacturer": "PIKO",
   "articleNumber": "51193",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 259.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 244 DR IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51193\nEAN: 4015615511939\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56634\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-244-dr-iv-49128.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51194.json
+++ b/articles/piko/51194.json
@@ -3,7 +3,7 @@
   "id": "piko-51194",
   "manufacturer": "PIKO",
   "articleNumber": "51194",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 244 DR IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51194\nEAN: 4015615511946\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-244-dr-iv,-inkl.-piko-sound-decoder-49129.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51195.json
+++ b/articles/piko/51195.json
@@ -3,7 +3,7 @@
   "id": "piko-51195",
   "manufacturer": "PIKO",
   "articleNumber": "51195",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 244 DR IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51195\nEAN: 4015615511953\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DR\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-244-dr-iv-wechselstromversion,-inkl.-piko-sound-decoder-49130.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51423.json
+++ b/articles/piko/51423.json
@@ -3,7 +3,7 @@
   "id": "piko-51423",
   "manufacturer": "PIKO",
   "articleNumber": "51423",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok E 32 DRG II Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51423\nEAN: 4015615514237\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 150\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56594\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-e-32-drg-ii-49086.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51424.json
+++ b/articles/piko/51424.json
@@ -3,7 +3,7 @@
   "id": "piko-51424",
   "manufacturer": "PIKO",
   "articleNumber": "51424",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 412.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok E 32 DRG II, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51424\nEAN: 4015615514244\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 150\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-e-32-drg-ii,-inkl.-piko-sound-decoder-49088.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51425.json
+++ b/articles/piko/51425.json
@@ -3,7 +3,7 @@
   "id": "piko-51425",
   "manufacturer": "PIKO",
   "articleNumber": "51425",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 412.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok E 32 DRG II Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51425\nEAN: 4015615514251\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DRG\nEpoche: II\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 150\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-e-32-drg-ii-wechselstromversion,-inkl.-piko-sound-decoder-49087.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51449.json
+++ b/articles/piko/51449.json
@@ -3,7 +3,7 @@
   "id": "piko-51449",
   "manufacturer": "PIKO",
   "articleNumber": "51449",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 255.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 431.194 MAV VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51449\nEAN: 4015615514497\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56598\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-431.194-mav-vi-49419.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51466.json
+++ b/articles/piko/51466.json
@@ -3,7 +3,7 @@
   "id": "piko-51466",
   "manufacturer": "PIKO",
   "articleNumber": "51466",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 439.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Triebzug EN 57 PKP SKM V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51466\nEAN: 4015615514664\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 747\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nKupplung: NEM Schacht + Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-triebzug-en-57-pkp-skm-v-48939.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51467.json
+++ b/articles/piko/51467.json
@@ -3,7 +3,7 @@
   "id": "piko-51467",
   "manufacturer": "PIKO",
   "articleNumber": "51467",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 549.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Triebzug EN 57 PKP SKM V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51467\nEAN: 4015615514671\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 747\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-triebzug-en-57-pkp-skm-v,-inkl.-piko-sound-decoder-48940.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51487.json
+++ b/articles/piko/51487.json
@@ -3,7 +3,7 @@
   "id": "piko-51487",
   "manufacturer": "PIKO",
   "articleNumber": "51487",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 194 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51487\nEAN: 4015615514879\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 214\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56601\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-194-db-iv-45714.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51488.json
+++ b/articles/piko/51488.json
@@ -3,7 +3,7 @@
   "id": "piko-51488",
   "manufacturer": "PIKO",
   "articleNumber": "51488",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 479.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 194 DB IV , inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51488\nEAN: 4015615514886\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 214\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-194-db-iv-,-inkl.-piko-sound-decoder-45715.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51489.json
+++ b/articles/piko/51489.json
@@ -3,7 +3,7 @@
   "id": "piko-51489",
   "manufacturer": "PIKO",
   "articleNumber": "51489",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 479.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 194 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51489\nEAN: 4015615514893\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 214\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-194-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-45716.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51616.json
+++ b/articles/piko/51616.json
@@ -3,7 +3,7 @@
   "id": "piko-51616",
   "manufacturer": "PIKO",
   "articleNumber": "51616",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 235.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 3E/1 PMP-PW IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51616\nEAN: 4015615516163\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56589\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-3e-1-pmp-pw-iv-45945.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51617.json
+++ b/articles/piko/51617.json
@@ -3,7 +3,7 @@
   "id": "piko-51617",
   "manufacturer": "PIKO",
   "articleNumber": "51617",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok 3E/1 PMP-PW IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51617\nEAN: 4015615516170\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-3e-1-pmp-pw-iv,-inkl.-piko-sound-decoder-45946.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51618.json
+++ b/articles/piko/51618.json
@@ -3,7 +3,7 @@
   "id": "piko-51618",
   "manufacturer": "PIKO",
   "articleNumber": "51618",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 235.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok ET 21 PKP III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51618\nEAN: 4015615516187\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56589\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-et-21-pkp-iii-49026.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51619.json
+++ b/articles/piko/51619.json
@@ -3,7 +3,7 @@
   "id": "piko-51619",
   "manufacturer": "PIKO",
   "articleNumber": "51619",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok ET 21 PKP III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51619\nEAN: 4015615516194\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-et-21-pkp-iii,-inkl.-piko-sound-decoder-49030.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51695.json
+++ b/articles/piko/51695.json
@@ -3,7 +3,7 @@
   "id": "piko-51695",
   "manufacturer": "PIKO",
   "articleNumber": "51695",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 219.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 103 DB AG V Orientrot Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51695\nEAN: 4015615516958\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 232\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56550\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-103-db-ag-v-orientrot-49023.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51696.json
+++ b/articles/piko/51696.json
@@ -3,7 +3,7 @@
   "id": "piko-51696",
   "manufacturer": "PIKO",
   "articleNumber": "51696",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 340.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 103 DB AG V Orientrot, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51696\nEAN: 4015615516965\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 232\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-103-db-ag-v-orientrot,-inkl.-piko-sound-decoder-49024.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51697.json
+++ b/articles/piko/51697.json
@@ -3,7 +3,7 @@
   "id": "piko-51697",
   "manufacturer": "PIKO",
   "articleNumber": "51697",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 340.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok BR 103 DB AG V Orientrot Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51697\nEAN: 4015615516972\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 232\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-103-db-ag-v-orientrot-wechselstromversion,-inkl.-piko-sound-decoder-49025.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51831.json
+++ b/articles/piko/51831.json
@@ -3,7 +3,7 @@
   "id": "piko-51831",
   "manufacturer": "PIKO",
   "articleNumber": "51831",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok E 52 DB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51831\nEAN: 4015615518310\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 198\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56574\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-e-52-db-iii-49131.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51832.json
+++ b/articles/piko/51832.json
@@ -3,7 +3,7 @@
   "id": "piko-51832",
   "manufacturer": "PIKO",
   "articleNumber": "51832",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 409.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok E 52 DB III inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51832\nEAN: 4015615518327\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IIII\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 198\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-e-52-db-iii-inkl.-piko-sound-decoder-49132.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/51833.json
+++ b/articles/piko/51833.json
@@ -3,7 +3,7 @@
   "id": "piko-51833",
   "manufacturer": "PIKO",
   "articleNumber": "51833",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 409.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok E 52 DB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51833\nEAN: 4015615518334\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 198\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-e-52-db-iii-wechselstromversion,-inkl.-piko-sound-decoder-49133.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52077.json
+++ b/articles/piko/52077.json
@@ -3,7 +3,7 @@
   "id": "piko-52077",
   "manufacturer": "PIKO",
   "articleNumber": "52077",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 332.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dieseltriebwagen \"Desiro\" Saarlandbahn DB AG VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52077\nEAN: 4015615520771\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56581\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dieseltriebwagen-desiro-saarlandbahn-db-ag-vi-49003.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52078.json
+++ b/articles/piko/52078.json
@@ -3,7 +3,7 @@
   "id": "piko-52078",
   "manufacturer": "PIKO",
   "articleNumber": "52078",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 441.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dieseltriebwagen \"Desiro\" Saarlandbahn DB AG VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52078\nEAN: 4015615520788\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dieseltriebwagen-desiro-saarlandbahn-db-ag-vi,-inkl.-piko-sound-decoder-49004.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52100.json
+++ b/articles/piko/52100.json
@@ -3,7 +3,7 @@
   "id": "piko-52100",
   "manufacturer": "PIKO",
   "articleNumber": "52100",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 195.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 211 VLTJ V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52100\nEAN: 4015615521006\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 141\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56624\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-211-vltj-v-45861.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52101.json
+++ b/articles/piko/52101.json
@@ -3,7 +3,7 @@
   "id": "piko-52101",
   "manufacturer": "PIKO",
   "articleNumber": "52101",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 305.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 211 VLTJ V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52101\nEAN: 4015615521013\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 141\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-211-vltj-v,-inkl.-piko-sound-decoder-45862.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52102.json
+++ b/articles/piko/52102.json
@@ -3,7 +3,7 @@
   "id": "piko-52102",
   "manufacturer": "PIKO",
   "articleNumber": "52102",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 305.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 211 VLTJ V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52102\nEAN: 4015615521020\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 141\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-211-vltj-v-wechselstromversion,-inkl.-piko-sound-decoder-45863.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52107.json
+++ b/articles/piko/52107.json
@@ -3,7 +3,7 @@
   "id": "piko-52107",
   "manufacturer": "PIKO",
   "articleNumber": "52107",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 200.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok ST44 PKP Cargo V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52107\nEAN: 4015615521075\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 202\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56538\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-st44-pkp-cargo-v-45490.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52108.json
+++ b/articles/piko/52108.json
@@ -3,7 +3,7 @@
   "id": "piko-52108",
   "manufacturer": "PIKO",
   "articleNumber": "52108",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 315.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok ST44 PKP Cargo V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52108\nEAN: 4015615521082\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 202\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-st44-pkp-cargo-v,-inkl.-piko-sound-decoder-45489.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52118.json
+++ b/articles/piko/52118.json
@@ -3,7 +3,7 @@
   "id": "piko-52118",
   "manufacturer": "PIKO",
   "articleNumber": "52118",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 154.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 228 Sparlack DR V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52118\nEAN: 4015615521181\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56557\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-228-sparlack-dr-v-48702.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52119.json
+++ b/articles/piko/52119.json
@@ -3,7 +3,7 @@
   "id": "piko-52119",
   "manufacturer": "PIKO",
   "articleNumber": "52119",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 264.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 228 Sparlack DR V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52119\nEAN: 4015615521198\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-228-sparlack-dr-v,-inkl.-piko-sound-decoder-48703.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52120.json
+++ b/articles/piko/52120.json
@@ -3,7 +3,7 @@
   "id": "piko-52120",
   "manufacturer": "PIKO",
   "articleNumber": "52120",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 264.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 228 Sparlack DR V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52120\nEAN: 4015615521204\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DR\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-228-sparlack-dr-v-wechselstromversion,-inkl.-piko-sound-decoder-48704.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52121.json
+++ b/articles/piko/52121.json
@@ -3,7 +3,7 @@
   "id": "piko-52121",
   "manufacturer": "PIKO",
   "articleNumber": "52121",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 155.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 219 DB AG V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52121\nEAN: 4015615521211\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56557\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-219-db-ag-v-48705.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52122.json
+++ b/articles/piko/52122.json
@@ -3,7 +3,7 @@
   "id": "piko-52122",
   "manufacturer": "PIKO",
   "articleNumber": "52122",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 219 DB AG V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52122\nEAN: 4015615521228\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-219-db-ag-v,-inkl.-piko-sound-decoder-48706.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52123.json
+++ b/articles/piko/52123.json
@@ -3,7 +3,7 @@
   "id": "piko-52123",
   "manufacturer": "PIKO",
   "articleNumber": "52123",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 219 DB AG V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52123\nEAN: 4015615521235\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-219-db-ag-v-wechselstromversion,-inkl.-piko-sound-decoder-48707.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52130.json
+++ b/articles/piko/52130.json
@@ -3,7 +3,7 @@
   "id": "piko-52130",
   "manufacturer": "PIKO",
   "articleNumber": "52130",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 195.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 211 Northrail VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52130\nEAN: 4015615521303\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56624\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-211-northrail-vi-49095.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52131.json
+++ b/articles/piko/52131.json
@@ -3,7 +3,7 @@
   "id": "piko-52131",
   "manufacturer": "PIKO",
   "articleNumber": "52131",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 305.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 211 Northrail VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52131\nEAN: 4015615521310\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-211-northrail-vi,-inkl.-piko-sound-decoder-49094.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52132.json
+++ b/articles/piko/52132.json
@@ -3,7 +3,7 @@
   "id": "piko-52132",
   "manufacturer": "PIKO",
   "articleNumber": "52132",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 305.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 211 Northrail VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52132\nEAN: 4015615521327\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-211-northrail-vi-wechselstromversion,-inkl.-piko-sound-decoder-49096.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52139.json
+++ b/articles/piko/52139.json
@@ -3,7 +3,7 @@
   "id": "piko-52139",
   "manufacturer": "PIKO",
   "articleNumber": "52139",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 200.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok CTLR4C-001, CTL Rail 4 Chem V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52139\nEAN: 4015615521396\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 202\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56538\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-ctlr4c-001,-ctl-rail-4-chem-v-49494.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52140.json
+++ b/articles/piko/52140.json
@@ -3,7 +3,7 @@
   "id": "piko-52140",
   "manufacturer": "PIKO",
   "articleNumber": "52140",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 315.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok CTLR4C-001, CTL Rail 4 Chem V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52140\nEAN: 4015615521402\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 202\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-ctlr4c-001,-ctl-rail-4-chem-v,-inkl.-piko-sound-decoder-49495.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52146.json
+++ b/articles/piko/52146.json
@@ -3,7 +3,7 @@
   "id": "piko-52146",
   "manufacturer": "PIKO",
   "articleNumber": "52146",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 189.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok T 669 CSD IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52146\nEAN: 4015615521464\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 199\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56542\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-t-669-csd-iv-49449.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52147.json
+++ b/articles/piko/52147.json
@@ -3,7 +3,7 @@
   "id": "piko-52147",
   "manufacturer": "PIKO",
   "articleNumber": "52147",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok T669 CSD IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52147\nEAN: 4015615521471\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 199\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-t669-csd-iv,-inkl.-piko-sound-decoder-49450.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52149.json
+++ b/articles/piko/52149.json
@@ -3,7 +3,7 @@
   "id": "piko-52149",
   "manufacturer": "PIKO",
   "articleNumber": "52149",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 299.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dieseltriebwagen BR 798 + Steuerwagen Ulmer Spatz DB AG V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52149\nEAN: 4015615521495\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 321\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nSound: PIKO Sound-Decoder nachrüstbar #56570\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Beleuchtete seitliche Zugzielanzeige\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dieseltriebwagen-br-798-steuerwagen-ulmer-spatz-db-ag-v-48968.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52150.json
+++ b/articles/piko/52150.json
@@ -3,7 +3,7 @@
   "id": "piko-52150",
   "manufacturer": "PIKO",
   "articleNumber": "52150",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 409.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Dieseltriebwagen BR 798 + Steuerwagen Ulmer Spatz DB AG V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52150\nEAN: 4015615521501\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 321\nMindestradius [mm]: 360\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Beleuchtete seitliche Zugzielanzeige\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-dieseltriebwagen-br-798-steuerwagen-ulmer-spatz-db-ag-v,-inkl.-piko-sound-decoder-48969.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52310.json
+++ b/articles/piko/52310.json
@@ -3,7 +3,7 @@
   "id": "piko-52310",
   "manufacturer": "PIKO",
   "articleNumber": "52310",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 195.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok Sm31 PKP V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52310\nEAN: 4015615523109\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56607\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sm31-pkp-v-45332.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52311.json
+++ b/articles/piko/52311.json
@@ -3,7 +3,7 @@
   "id": "piko-52311",
   "manufacturer": "PIKO",
   "articleNumber": "52311",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 305.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Sm31 PKP V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52311\nEAN: 4015615523116\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sm31-pkp-v,-inkl.-piko-sound-decoder-45333.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52336.json
+++ b/articles/piko/52336.json
@@ -3,7 +3,7 @@
   "id": "piko-52336",
   "manufacturer": "PIKO",
   "articleNumber": "52336",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 195.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 213 orientrot DB AG V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52336\nEAN: 4015615523369\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56624\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-213-orientrot-db-ag-v-45733.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52337.json
+++ b/articles/piko/52337.json
@@ -3,7 +3,7 @@
   "id": "piko-52337",
   "manufacturer": "PIKO",
   "articleNumber": "52337",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 305.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 213 orientrot DB AG V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52337\nEAN: 4015615523376\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-213-orientrot-db-ag-v,-inkl.-piko-sound-decoder-45734.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52338.json
+++ b/articles/piko/52338.json
@@ -3,7 +3,7 @@
   "id": "piko-52338",
   "manufacturer": "PIKO",
   "articleNumber": "52338",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 305.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 213 orientrot DB AG V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52338\nEAN: 4015615523383\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-213-orientrot-db-ag-v-wechselstromversion,-inkl.-piko-sound-decoder-45735.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52376.json
+++ b/articles/piko/52376.json
@@ -3,7 +3,7 @@
   "id": "piko-52376",
   "manufacturer": "PIKO",
   "articleNumber": "52376",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 259.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok DE18 SBB Cargo International VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52376\nEAN: 4015615523765\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: SBB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56635\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-de18-sbb-cargo-international-vi-49289.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52377.json
+++ b/articles/piko/52377.json
@@ -3,7 +3,7 @@
   "id": "piko-52377",
   "manufacturer": "PIKO",
   "articleNumber": "52377",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok DE18 SBB Cargo International VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52377\nEAN: 4015615523772\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SBB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-sbb-cargo-international-vi,-inkl.-piko-sound-decoder-49290.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52378.json
+++ b/articles/piko/52378.json
@@ -3,7 +3,7 @@
   "id": "piko-52378",
   "manufacturer": "PIKO",
   "articleNumber": "52378",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 369.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok DE18 SBB Cargo Int. VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52378\nEAN: 4015615523789\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: SBB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-sbb-cargo-int.-vi-wechselstromversion,-inkl.-piko-sound-decoder-49291.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52380.json
+++ b/articles/piko/52380.json
@@ -3,7 +3,7 @@
   "id": "piko-52380",
   "manufacturer": "PIKO",
   "articleNumber": "52380",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 209.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok M44 MAV III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52380\nEAN: 4015615523802\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56646\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-m44-mav-iii-48018.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52382.json
+++ b/articles/piko/52382.json
@@ -3,7 +3,7 @@
   "id": "piko-52382",
   "manufacturer": "PIKO",
   "articleNumber": "52382",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 319.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok M44 MAV III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52382\nEAN: 4015615523826\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-m44-mav-iii,-inkl.-piko-sound-decoder-48020.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52383.json
+++ b/articles/piko/52383.json
@@ -3,7 +3,7 @@
   "id": "piko-52383",
   "manufacturer": "PIKO",
   "articleNumber": "52383",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 319.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok M44 MAV III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52383\nEAN: 4015615523833\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: MAV\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-m44-mav-iii-wechselstromversion,-inkl.-piko-sound-decoder-48021.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52384.json
+++ b/articles/piko/52384.json
@@ -3,7 +3,7 @@
   "id": "piko-52384",
   "manufacturer": "PIKO",
   "articleNumber": "52384",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 209.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok T455.0 CSD III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52384\nEAN: 4015615523840\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56646\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-t455.0-csd-iii-48022.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52385.json
+++ b/articles/piko/52385.json
@@ -3,7 +3,7 @@
   "id": "piko-52385",
   "manufacturer": "PIKO",
   "articleNumber": "52385",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 319.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok T455.0 CSD III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52385\nEAN: 4015615523857\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-t455.0-csd-iii,-inkl.-piko-sound-decoder-48023.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52386.json
+++ b/articles/piko/52386.json
@@ -3,7 +3,7 @@
   "id": "piko-52386",
   "manufacturer": "PIKO",
   "articleNumber": "52386",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 319.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok T455.0 CSD III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52386\nEAN: 4015615523864\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CSD\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-t455.0-csd-iii-wechselstromversion,-inkl.-piko-sound-decoder-48024.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52387.json
+++ b/articles/piko/52387.json
@@ -3,7 +3,7 @@
   "id": "piko-52387",
   "manufacturer": "PIKO",
   "articleNumber": "52387",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 209.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok Sm41 PKP IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52387\nEAN: 4015615523871\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56646\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sm41-pkp-iv-48025.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52388.json
+++ b/articles/piko/52388.json
@@ -3,7 +3,7 @@
   "id": "piko-52388",
   "manufacturer": "PIKO",
   "articleNumber": "52388",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 319.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Sm41 PKP IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52388\nEAN: 4015615523888\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sm41-pkp-iv,-inkl.-piko-sound-decoder-48026.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52389.json
+++ b/articles/piko/52389.json
@@ -3,7 +3,7 @@
   "id": "piko-52389",
   "manufacturer": "PIKO",
   "articleNumber": "52389",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 319.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Sm41 PKP IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52389\nEAN: 4015615523895\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: PKP\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 130\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sm41-pkp-iv-wechselstromversion,-inkl.-piko-sound-decoder-48027.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52584.json
+++ b/articles/piko/52584.json
@@ -3,7 +3,7 @@
   "id": "piko-52584",
   "manufacturer": "PIKO",
   "articleNumber": "52584",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 179.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok V200 1001 DR III, Messe Leipzig Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52584\nEAN: 4015615525844\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56554\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-v200-1001-dr-iii,-messe-leipzig-49377.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52585.json
+++ b/articles/piko/52585.json
@@ -3,7 +3,7 @@
   "id": "piko-52585",
   "manufacturer": "PIKO",
   "articleNumber": "52585",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 289.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok V200 1001 DR III, Messe Leipzig inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52585\nEAN: 4015615525851\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-v200-1001-dr-iii,-messe-leipzig-inkl.-piko-sound-decoder-49378.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52586.json
+++ b/articles/piko/52586.json
@@ -3,7 +3,7 @@
   "id": "piko-52586",
   "manufacturer": "PIKO",
   "articleNumber": "52586",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 289.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok V200 1001 DR III, Messe Leipzig Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52586\nEAN: 4015615525868\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DR\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-v200-1001-dr-iii,-messe-leipzig-wechselstromversion,-inkl.-piko-sound-decoder-49379.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52617.json
+++ b/articles/piko/52617.json
@@ -3,7 +3,7 @@
   "id": "piko-52617",
   "manufacturer": "PIKO",
   "articleNumber": "52617",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 175.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 221 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52617\nEAN: 4015615526179\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 212\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56559\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-221-db-iv-49097.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52618.json
+++ b/articles/piko/52618.json
@@ -3,7 +3,7 @@
   "id": "piko-52618",
   "manufacturer": "PIKO",
   "articleNumber": "52618",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 285.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 221 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52618\nEAN: 4015615526186\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 212\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-221-db-iv,-inkl.-piko-sound-decoder-49098.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52619.json
+++ b/articles/piko/52619.json
@@ -3,7 +3,7 @@
   "id": "piko-52619",
   "manufacturer": "PIKO",
   "articleNumber": "52619",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 285.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 221 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52619\nEAN: 4015615526193\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 212\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-221-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49099.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52717.json
+++ b/articles/piko/52717.json
@@ -3,7 +3,7 @@
   "id": "piko-52717",
   "manufacturer": "PIKO",
   "articleNumber": "52717",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 154.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 228 Cargo Logistic Rail VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52717\nEAN: 4015615527176\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56557\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-228-cargo-logistic-rail-vi-45535.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52718.json
+++ b/articles/piko/52718.json
@@ -3,7 +3,7 @@
   "id": "piko-52718",
   "manufacturer": "PIKO",
   "articleNumber": "52718",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 264.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 228 Cargo Logistic Rail VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52718\nEAN: 4015615527183\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-228-cargo-logistic-rail-vi,-inkl.-piko-sound-decoder-45536.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52719.json
+++ b/articles/piko/52719.json
@@ -3,7 +3,7 @@
   "id": "piko-52719",
   "manufacturer": "PIKO",
   "articleNumber": "52719",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 264.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 228 Cargo Logistic Rail VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52719\nEAN: 4015615527190\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-228-cargo-logistic-rail-vi-wechselstromversion,-inkl.-piko-sound-decoder-45537.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52876.json
+++ b/articles/piko/52876.json
@@ -3,7 +3,7 @@
   "id": "piko-52876",
   "manufacturer": "PIKO",
   "articleNumber": "52876",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 235.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok SU46 PKP V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52876\nEAN: 4015615528760\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56533\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-su46-pkp-v-45503.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52877.json
+++ b/articles/piko/52877.json
@@ -3,7 +3,7 @@
   "id": "piko-52877",
   "manufacturer": "PIKO",
   "articleNumber": "52877",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 345.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok SU46 PKP V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52877\nEAN: 4015615528777\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-su46-pkp-v,-inkl.-piko-sound-decoder-45504.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/52979.json
+++ b/articles/piko/52979.json
@@ -3,7 +3,7 @@
   "id": "piko-52979",
   "manufacturer": "PIKO",
   "articleNumber": "52979",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 332.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Dieseltriebwagen \"Desiro\" bwegt DB AG VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52979\nEAN: 4015615529798\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56581\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/dieseltriebwagen-desiro-bwegt-db-ag-vi-44855.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57346.json
+++ b/articles/piko/57346.json
@@ -3,7 +3,7 @@
   "id": "piko-57346",
   "manufacturer": "PIKO",
   "articleNumber": "57346",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 170.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellokomotive TRAXX Press VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57346\nEAN: 4015615573463\nHersteller: PIKO\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellokomotive-traxx-press-vi-wechselstromversion-49287.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57368.json
+++ b/articles/piko/57368.json
@@ -3,7 +3,7 @@
   "id": "piko-57368",
   "manufacturer": "PIKO",
   "articleNumber": "57368",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 293.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Schlepptenderlok BR 55 (G7.1) NS III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57368\nEAN: 4015615573685\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-br-55-g7.1-ns-iii-wechselstromversion,-inkl.-piko-sound-decoder-45479.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57408.json
+++ b/articles/piko/57408.json
@@ -3,7 +3,7 @@
   "id": "piko-57408",
   "manufacturer": "PIKO",
   "articleNumber": "57408",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 88.5,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Taurus CityJet ÖBB VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57408\nEAN: 4015615574088\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 221\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56638\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-taurus-cityjet-oebb-vi-49509.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57409.json
+++ b/articles/piko/57409.json
@@ -3,7 +3,7 @@
   "id": "piko-57409",
   "manufacturer": "PIKO",
   "articleNumber": "57409",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 142.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Taurus CityJet ÖBB VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57409\nEAN: 4015615574095\nHersteller: PIKO\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 221\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56638\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-taurus-cityjet-oebb-vi-wechselstromversion-49568.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57546.json
+++ b/articles/piko/57546.json
@@ -3,7 +3,7 @@
   "id": "piko-57546",
   "manufacturer": "PIKO",
   "articleNumber": "57546",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 115.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellokomotive TRAXX Press VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57546\nEAN: 4015615575467\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellokomotive-traxx-press-vi-49286.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57568.json
+++ b/articles/piko/57568.json
@@ -3,7 +3,7 @@
   "id": "piko-57568",
   "manufacturer": "PIKO",
   "articleNumber": "57568",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 179.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Schlepptenderlok BR 55 (G7.1) NS III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57568\nEAN: 4015615575689\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder nachrüstbar #56629\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/schlepptenderlok-br-55-g7.1-ns-iii-46129.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57569.json
+++ b/articles/piko/57569.json
@@ -3,7 +3,7 @@
   "id": "piko-57569",
   "manufacturer": "PIKO",
   "articleNumber": "57569",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 293.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Schlepptenderlok BR 55 (G7.1) NS III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57569\nEAN: 4015615575696\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-br-55-g7.1-ns-iii,-inkl.-piko-sound-decoder-45478.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57870.json
+++ b/articles/piko/57870.json
@@ -3,7 +3,7 @@
   "id": "piko-57870",
   "manufacturer": "PIKO",
   "articleNumber": "57870",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 122.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 185 Beacon VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57870\nEAN: 4015615578703\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-185-beacon-vi-49458.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57871.json
+++ b/articles/piko/57871.json
@@ -3,7 +3,7 @@
   "id": "piko-57871",
   "manufacturer": "PIKO",
   "articleNumber": "57871",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 175.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 185 Beacon VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57871\nEAN: 4015615578710\nHersteller: PIKO\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-polig\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-185-beacon-vi-wechselstromversion-49459.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57876.json
+++ b/articles/piko/57876.json
@@ -3,7 +3,7 @@
   "id": "piko-57876",
   "manufacturer": "PIKO",
   "articleNumber": "57876",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 175.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 145 MEG VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57876\nEAN: 4015615578765\nHersteller: PIKO\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-145-meg-vi-wechselstromversion-45713.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57877.json
+++ b/articles/piko/57877.json
@@ -3,7 +3,7 @@
   "id": "piko-57877",
   "manufacturer": "PIKO",
   "articleNumber": "57877",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 122.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 185 329 Black Dragons VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57877\nEAN: 4015615578772\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-185-329-black-dragons-vi-49507.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57878.json
+++ b/articles/piko/57878.json
@@ -3,7 +3,7 @@
   "id": "piko-57878",
   "manufacturer": "PIKO",
   "articleNumber": "57878",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 175.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 185 329 Black Dragons VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57878\nEAN: 4015615578789\nHersteller: PIKO\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-polig\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-185-329-black-dragons-vi-wechselstromversion-49508.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/57976.json
+++ b/articles/piko/57976.json
@@ -3,7 +3,7 @@
   "id": "piko-57976",
   "manufacturer": "PIKO",
   "articleNumber": "57976",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 122.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok BR 145 MEG VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57976\nEAN: 4015615579762\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nBesonderheiten: Lokführerfigur im Führerstand\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-br-145-meg-vi-45711.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/58152.json
+++ b/articles/piko/58152.json
@@ -3,7 +3,7 @@
   "id": "piko-58152",
   "manufacturer": "PIKO",
   "articleNumber": "58152",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 669.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Zugset 4tlg. Metropolitan BR 101 mit Personenwagen und Steuerwagen DB AG VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 58152\nEAN: 4015615581529\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: Länge des Zuges\nMaß [mm]: 1131\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56600\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Inkl. Innenbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/zugset-4tlg.-metropolitan-br-101-mit-personenwagen-und-steuerwagen-db-ag-vi-43693.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/58153.json
+++ b/articles/piko/58153.json
@@ -3,7 +3,7 @@
   "id": "piko-58153",
   "manufacturer": "PIKO",
   "articleNumber": "58153",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 779.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Zugset 4tlg. Metropolitan BR 101 mit Personenwagen und Steuerwagen DB AG VI, inkl. PIKO Sound Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 58153\nEAN: 4015615581536\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: Länge des Zuges\nMaß [mm]: 1131\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Inkl. Innenbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-zugset-4tlg.-metropolitan-br-101-mit-personenwagen-und-steuerwagen-db-ag-vi,-inkl.-piko-sound-43694.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59078.json
+++ b/articles/piko/59078.json
@@ -3,7 +3,7 @@
   "id": "piko-59078",
   "manufacturer": "PIKO",
   "articleNumber": "59078",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 205.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok G 1700 Schweerbau VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59078\nEAN: 4015615590781\nHersteller: PIKO\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56652\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-g-1700-schweerbau-vi-wechselstromversion-45339.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59079.json
+++ b/articles/piko/59079.json
@@ -3,7 +3,7 @@
   "id": "piko-59079",
   "manufacturer": "PIKO",
   "articleNumber": "59079",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 205.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok G 1700 GKB VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59079\nEAN: 4015615590798\nHersteller: PIKO\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56652\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-g-1700-gkb-vi-wechselstromversion-45342.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59123.json
+++ b/articles/piko/59123.json
@@ -3,7 +3,7 @@
   "id": "piko-59123",
   "manufacturer": "PIKO",
   "articleNumber": "59123",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 189.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok Vectron BR 247 Sersa VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59123\nEAN: 4015615591238\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56553\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-vectron-br-247-sersa-vi-49100.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59124.json
+++ b/articles/piko/59124.json
@@ -3,7 +3,7 @@
   "id": "piko-59124",
   "manufacturer": "PIKO",
   "articleNumber": "59124",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 300.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Vectron BR 247 Sersa VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59124\nEAN: 4015615591245\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-vectron-br-247-sersa-vi,-inkl.-piko-sound-decoder-49101.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59125.json
+++ b/articles/piko/59125.json
@@ -3,7 +3,7 @@
   "id": "piko-59125",
   "manufacturer": "PIKO",
   "articleNumber": "59125",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 300.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok Vectron BR 247 Sersa VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59125\nEAN: 4015615591252\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-vectron-br-247-sersa-vi-wechselstromversion,-inkl.-piko-sound-decoder-49102.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59167.json
+++ b/articles/piko/59167.json
@@ -3,7 +3,7 @@
   "id": "piko-59167",
   "manufacturer": "PIKO",
   "articleNumber": "59167",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 155.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok 6400 Railion Logistics NL VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59167\nEAN: 4015615591672\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56555\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-6400-railion-logistics-nl-vi-45721.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59168.json
+++ b/articles/piko/59168.json
@@ -3,7 +3,7 @@
   "id": "piko-59168",
   "manufacturer": "PIKO",
   "articleNumber": "59168",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok 6400 Railion Logistics NL VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59168\nEAN: 4015615591689\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-6400-railion-logistics-nl-vi,-inkl.-piko-sound-decoder-45722.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59169.json
+++ b/articles/piko/59169.json
@@ -3,7 +3,7 @@
   "id": "piko-59169",
   "manufacturer": "PIKO",
   "articleNumber": "59169",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok 6400 Railion Logistics NL VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59169\nEAN: 4015615591696\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-6400-railion-logistics-nl-vi-wechselstromversion,-inkl.-piko-sound-decoder-45723.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59178.json
+++ b/articles/piko/59178.json
@@ -3,7 +3,7 @@
   "id": "piko-59178",
   "manufacturer": "PIKO",
   "articleNumber": "59178",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 164.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok G 1700 Schweerbau VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59178\nEAN: 4015615591788\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56652\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-g-1700-schweerbau-vi-45340.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59179.json
+++ b/articles/piko/59179.json
@@ -3,7 +3,7 @@
   "id": "piko-59179",
   "manufacturer": "PIKO",
   "articleNumber": "59179",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 164.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok G 1700 GKB VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59179\nEAN: 4015615591795\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56652\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-g-1700-gkb-vi-45341.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59277.json
+++ b/articles/piko/59277.json
@@ -3,7 +3,7 @@
   "id": "piko-59277",
   "manufacturer": "PIKO",
   "articleNumber": "59277",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 179.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok SM42 Cemet VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59277\nEAN: 4015615592778\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 164\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sm42-cemet-vi-49492.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59278.json
+++ b/articles/piko/59278.json
@@ -3,7 +3,7 @@
   "id": "piko-59278",
   "manufacturer": "PIKO",
   "articleNumber": "59278",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 179.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok SM42 PNI VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59278\nEAN: 4015615592785\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 164\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sm42-pni-vi-49493.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59370.json
+++ b/articles/piko/59370.json
@@ -3,7 +3,7 @@
   "id": "piko-59370",
   "manufacturer": "PIKO",
   "articleNumber": "59370",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 155.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok G 1206 Northrail VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59370\nEAN: 4015615593706\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56555\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-g-1206-northrail-vi-49106.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59371.json
+++ b/articles/piko/59371.json
@@ -3,7 +3,7 @@
   "id": "piko-59371",
   "manufacturer": "PIKO",
   "articleNumber": "59371",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok G 1206 Northrail VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59371\nEAN: 4015615593713\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-g-1206-northrail-vi,-inkl.-piko-sound-decoder-49107.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59372.json
+++ b/articles/piko/59372.json
@@ -3,7 +3,7 @@
   "id": "piko-59372",
   "manufacturer": "PIKO",
   "articleNumber": "59372",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok G 1206 Northrail VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59372\nEAN: 4015615593720\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-g-1206-northrail-vi-wechselstromversion,-inkl.-piko-sound-decoder-49108.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59373.json
+++ b/articles/piko/59373.json
@@ -3,7 +3,7 @@
   "id": "piko-59373",
   "manufacturer": "PIKO",
   "articleNumber": "59373",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 155.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok G 1206 RailCargoGroup VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59373\nEAN: 4015615593737\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56555\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-g-1206-railcargogroup-vi-49111.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59374.json
+++ b/articles/piko/59374.json
@@ -3,7 +3,7 @@
   "id": "piko-59374",
   "manufacturer": "PIKO",
   "articleNumber": "59374",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok G 1206 RailCargoGroup VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59374\nEAN: 4015615593744\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-g-1206-railcargogroup-vi,-inkl.-piko-sound-decoder-49110.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59375.json
+++ b/articles/piko/59375.json
@@ -3,7 +3,7 @@
   "id": "piko-59375",
   "manufacturer": "PIKO",
   "articleNumber": "59375",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok G 1206 RailCargoGroup VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59375\nEAN: 4015615593751\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-g-1206-railcargogroup-vi-wechselstromversion,-inkl.-piko-sound-decoder-49109.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59376.json
+++ b/articles/piko/59376.json
@@ -3,7 +3,7 @@
   "id": "piko-59376",
   "manufacturer": "PIKO",
   "articleNumber": "59376",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 155.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok G 1206 RTS-Swietelsky NL VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59376\nEAN: 4015615593768\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56555\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-g-1206-rts-swietelsky-nl-vi-49105.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59377.json
+++ b/articles/piko/59377.json
@@ -3,7 +3,7 @@
   "id": "piko-59377",
   "manufacturer": "PIKO",
   "articleNumber": "59377",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok G 1206 RTS-Swietelsky NL VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59377\nEAN: 4015615593775\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-g-1206-rts-swietelsky-nl-vi,-inkl.-piko-sound-decoder-49103.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59378.json
+++ b/articles/piko/59378.json
@@ -3,7 +3,7 @@
   "id": "piko-59378",
   "manufacturer": "PIKO",
   "articleNumber": "59378",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 265.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok G 1206 RTS-Swietelsky NL VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59378\nEAN: 4015615593782\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 169\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-g-1206-rts-swietelsky-nl-vi-wechselstromversion,-inkl.-piko-sound-decoder-49104.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59726.json
+++ b/articles/piko/59726.json
@@ -3,7 +3,7 @@
   "id": "piko-59726",
   "manufacturer": "PIKO",
   "articleNumber": "59726",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 165.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BR 220 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59726\nEAN: 4015615597261\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 213\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56541\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-br-220-db-iv-49077.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59727.json
+++ b/articles/piko/59727.json
@@ -3,7 +3,7 @@
   "id": "piko-59727",
   "manufacturer": "PIKO",
   "articleNumber": "59727",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 275.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 220 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59727\nEAN: 4015615597278\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 213\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-220-db-iv,-inkl.-piko-sound-decoder-49078.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59728.json
+++ b/articles/piko/59728.json
@@ -3,7 +3,7 @@
   "id": "piko-59728",
   "manufacturer": "PIKO",
   "articleNumber": "59728",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 275.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BR 220 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59728\nEAN: 4015615597285\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 213\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-220-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-49079.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59762.json
+++ b/articles/piko/59762.json
@@ -3,7 +3,7 @@
   "id": "piko-59762",
   "manufacturer": "PIKO",
   "articleNumber": "59762",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 179.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok T 679.2 CSD IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59762\nEAN: 4015615597629\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 237\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56540\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-t-679.2-csd-iv-49510.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59763.json
+++ b/articles/piko/59763.json
@@ -3,7 +3,7 @@
   "id": "piko-59763",
   "manufacturer": "PIKO",
   "articleNumber": "59763",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 289.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok T 679.2 CSD IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59763\nEAN: 4015615597636\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 237\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-t-679.2-csd-iv,-inkl.-piko-sound-decoder-49511.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/59779.json
+++ b/articles/piko/59779.json
@@ -3,7 +3,7 @@
   "id": "piko-59779",
   "manufacturer": "PIKO",
   "articleNumber": "59779",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 189.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok S-200 CTL Logistics VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59779\nEAN: 4015615597797\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 199\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56542\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-s-200-ctl-logistics-vi-46027.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96316.json
+++ b/articles/piko/96316.json
@@ -3,7 +3,7 @@
   "id": "piko-96316",
   "manufacturer": "PIKO",
   "articleNumber": "96316",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 215.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok SU45 PKP V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96316\nEAN: 4015615963165\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56561\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-su45-pkp-v-49172.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96317.json
+++ b/articles/piko/96317.json
@@ -3,7 +3,7 @@
   "id": "piko-96317",
   "manufacturer": "PIKO",
   "articleNumber": "96317",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 325.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok SU45 PKP V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96317\nEAN: 4015615963172\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-su45-pkp-v,-inkl.-piko-sound-decoder-49173.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96347.json
+++ b/articles/piko/96347.json
@@ -3,7 +3,7 @@
   "id": "piko-96347",
   "manufacturer": "PIKO",
   "articleNumber": "96347",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 225.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 201E-277, PL-WISKO Wiskol (LOTOS) VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96347\nEAN: 4015615963479\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 221\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56569\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-201e-277,-pl-wisko-wiskol-lotos-vi-49417.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96348.json
+++ b/articles/piko/96348.json
@@ -3,7 +3,7 @@
   "id": "piko-96348",
   "manufacturer": "PIKO",
   "articleNumber": "96348",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 335.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok 201E-277, PL-WISKO Wiskol (LOTOS) VI inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96348\nEAN: 4015615963486\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 221\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-201e-277,-pl-wisko-wiskol-lotos-vi-inkl.-piko-sound-decoder-49418.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96358.json
+++ b/articles/piko/96358.json
@@ -3,7 +3,7 @@
   "id": "piko-96358",
   "manufacturer": "PIKO",
   "articleNumber": "96358",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 219.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok EU07 PKP V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96358\nEAN: 4015615963585\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56552\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Oberleitungsbetrieb möglich\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-eu07-pkp-v-45487.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96359.json
+++ b/articles/piko/96359.json
@@ -3,7 +3,7 @@
   "id": "piko-96359",
   "manufacturer": "PIKO",
   "articleNumber": "96359",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 329.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok EU07 PKP V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96359\nEAN: 4015615963592\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Oberleitungsbetrieb möglich",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-eu07-pkp-v,-inkl.-piko-sound-decoder-45488.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96395.json
+++ b/articles/piko/96395.json
@@ -3,7 +3,7 @@
   "id": "piko-96395",
   "manufacturer": "PIKO",
   "articleNumber": "96395",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 339.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok ET41 PKP Cargo VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96395\nEAN: 4015615963950\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56552\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Oberleitungsbetrieb möglich\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-et41-pkp-cargo-vi-45529.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96396.json
+++ b/articles/piko/96396.json
@@ -3,7 +3,7 @@
   "id": "piko-96396",
   "manufacturer": "PIKO",
   "articleNumber": "96396",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 449.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok ET41 PKP Cargo VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96396\nEAN: 4015615963967\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Oberleitungsbetrieb möglich",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-et41-pkp-cargo-vi,-inkl.-piko-sound-decoder-45530.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96493.json
+++ b/articles/piko/96493.json
@@ -3,7 +3,7 @@
   "id": "piko-96493",
   "manufacturer": "PIKO",
   "articleNumber": "96493",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 274.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok BB 60000 SNCF VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96493\nEAN: 4015615964933\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: SNCF\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56527\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-bb-60000-sncf-vi-45329.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/96494.json
+++ b/articles/piko/96494.json
@@ -3,7 +3,7 @@
   "id": "piko-96494",
   "manufacturer": "PIKO",
   "articleNumber": "96494",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 394.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok BB 60000 SNCF VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96494\nEAN: 4015615964940\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SNCF\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-bb-60000-sncf-vi,-inkl.-piko-sound-decoder-45330.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97504.json
+++ b/articles/piko/97504.json
@@ -3,7 +3,7 @@
   "id": "piko-97504",
   "manufacturer": "PIKO",
   "articleNumber": "97504",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 245.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok Rh 1000 NS IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97504\nEAN: 4015615975045\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 187\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56632\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-1000-ns-iv-44764.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97505.json
+++ b/articles/piko/97505.json
@@ -3,7 +3,7 @@
   "id": "piko-97505",
   "manufacturer": "PIKO",
   "articleNumber": "97505",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 355.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1000 NS IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97505\nEAN: 4015615975052\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 187\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1000-ns-iv,-inkl.-piko-sound-decoder-44765.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97506.json
+++ b/articles/piko/97506.json
@@ -3,7 +3,7 @@
   "id": "piko-97506",
   "manufacturer": "PIKO",
   "articleNumber": "97506",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 355.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok Rh 1000 NS IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97506\nEAN: 4015615975069\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 187\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1000-ns-iv-wechselstromversion,-inkl.-piko-sound-decoder-44766.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97507.json
+++ b/articles/piko/97507.json
@@ -3,7 +3,7 @@
   "id": "piko-97507",
   "manufacturer": "PIKO",
   "articleNumber": "97507",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 245.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok 1008 NS III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97507\nEAN: 4015615975076\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 187\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56632\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-1008-ns-iii-49074.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97508.json
+++ b/articles/piko/97508.json
@@ -3,7 +3,7 @@
   "id": "piko-97508",
   "manufacturer": "PIKO",
   "articleNumber": "97508",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 355.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok 1008 NS III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97508\nEAN: 4015615975083\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 187\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-1008-ns-iii,-inkl.-piko-sound-decoder-49075.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97509.json
+++ b/articles/piko/97509.json
@@ -3,7 +3,7 @@
   "id": "piko-97509",
   "manufacturer": "PIKO",
   "articleNumber": "97509",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 355.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok 1008 NS III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97509\nEAN: 4015615975090\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: NS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 187\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-1008-ns-iii-wechselstromversion,-inkl.-piko-sound-decoder-49076.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97532.json
+++ b/articles/piko/97532.json
@@ -3,7 +3,7 @@
   "id": "piko-97532",
   "manufacturer": "PIKO",
   "articleNumber": "97532",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 249.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "E-Lok EP09 PKP IC VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97532\nEAN: 4015615975328\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56636\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/e-lok-ep09-pkp-ic-vi-49408.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97533.json
+++ b/articles/piko/97533.json
@@ -3,7 +3,7 @@
   "id": "piko-97533",
   "manufacturer": "PIKO",
   "articleNumber": "97533",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 359.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-E-Lok EP09 PKP IC IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97533\nEAN: 4015615975335\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-ep09-pkp-ic-iv,-inkl.-piko-sound-decoder-49409.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97540.json
+++ b/articles/piko/97540.json
@@ -3,7 +3,7 @@
   "id": "piko-97540",
   "manufacturer": "PIKO",
   "articleNumber": "97540",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 320.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok CC 65000 SNCF Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97540\nEAN: 4015615975403\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: SNCF\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56658\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-cc-65000-sncf-49018.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97542.json
+++ b/articles/piko/97542.json
@@ -3,7 +3,7 @@
   "id": "piko-97542",
   "manufacturer": "PIKO",
   "articleNumber": "97542",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 450.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok CC 65000 SNCF Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97542\nEAN: 4015615975427\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SNCF\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 188\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-cc-65000-sncf-49019.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97831.json
+++ b/articles/piko/97831.json
@@ -3,7 +3,7 @@
   "id": "piko-97831",
   "manufacturer": "PIKO",
   "articleNumber": "97831",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok ML 4001 D&RGW modifiziert Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97831\nEAN: 4015615978312\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: D&RGW\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nSound: PIKO Sound-Decoder nachrüstbar #56627\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-ml-4001-d-und-rgw-modifiziert-45696.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97832.json
+++ b/articles/piko/97832.json
@@ -3,7 +3,7 @@
   "id": "piko-97832",
   "manufacturer": "PIKO",
   "articleNumber": "97832",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 449.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok ML 4001 D&RGW modifiziert, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97832\nEAN: 4015615978329\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: D&RGW\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-ml-4001-d-und-rgw-modifiziert,-inkl.-piko-sound-decoder-45697.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97833.json
+++ b/articles/piko/97833.json
@@ -3,7 +3,7 @@
   "id": "piko-97833",
   "manufacturer": "PIKO",
   "articleNumber": "97833",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 449.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Sound-Diesellok ML 4001 D&RGW modifiziert Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97833\nEAN: 4015615978336\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: D&RGW\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-ml-4001-d-und-rgw-modifiziert-wechselstromversion,-inkl.-piko-sound-decoder-45698.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97834.json
+++ b/articles/piko/97834.json
@@ -3,7 +3,7 @@
   "id": "piko-97834",
   "manufacturer": "PIKO",
   "articleNumber": "97834",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok D&RGW 4003 modifiziert Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97834\nEAN: 4015615978343\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: D&RGW\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nSound: PIKO Sound-Decoder nachrüstbar #56627\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-d-und-rgw-4003-modifiziert-45699.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97835.json
+++ b/articles/piko/97835.json
@@ -3,7 +3,7 @@
   "id": "piko-97835",
   "manufacturer": "PIKO",
   "articleNumber": "97835",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 449.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok/Sound D&RGW 4003 modifiziert, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97835\nEAN: 4015615978350\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: D&RGW\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sound-d-und-rgw-4003-modifiziert,-inkl.-piko-sound-decoder-45700.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97836.json
+++ b/articles/piko/97836.json
@@ -3,7 +3,7 @@
   "id": "piko-97836",
   "manufacturer": "PIKO",
   "articleNumber": "97836",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 449.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "~Diesellok/Sound D&RGW 4003 modifiziert Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97836\nEAN: 4015615978367\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: D&RGW\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/~diesellok-sound-d-und-rgw-4003-modifiziert-wechselstromversion,-inkl.-piko-sound-decoder-45701.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97837.json
+++ b/articles/piko/97837.json
@@ -3,7 +3,7 @@
   "id": "piko-97837",
   "manufacturer": "PIKO",
   "articleNumber": "97837",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 349.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok SP 9022 modifiziert Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97837\nEAN: 4015615978374\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: SP (Southern Pacific)\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nSound: PIKO Sound-Decoder nachrüstbar #56627\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sp-9022-modifiziert-45702.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97838.json
+++ b/articles/piko/97838.json
@@ -3,7 +3,7 @@
   "id": "piko-97838",
   "manufacturer": "PIKO",
   "articleNumber": "97838",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 449.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok/Sound SP 9022 modifiziert, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97838\nEAN: 4015615978381\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SP (Southern Pacific)\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sound-sp-9022-modifiziert,-inkl.-piko-sound-decoder-45703.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/articles/piko/97839.json
+++ b/articles/piko/97839.json
@@ -3,7 +3,7 @@
   "id": "piko-97839",
   "manufacturer": "PIKO",
   "articleNumber": "97839",
-  "releaseDate": null,
+  "releaseDate": "2026",
   "uvp": {
     "amount": 449.0,
     "currency": "EUR"
@@ -23,7 +23,9 @@
   },
   "description": "Diesellok/Sound SP 9022 modifiziert Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97839\nEAN: 4015615978398\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: SP (Southern Pacific)\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
   "categories": [],
-  "tags": [],
+  "tags": [
+    "piko-neuheiten-2026"
+  ],
   "source": {
     "url": "https://www.piko-shop.de/de/artikel/diesellok-sound-sp-9022-modifiziert-wechselstromversion,-inkl.-piko-sound-decoder-45704.html",
     "notes": "Daten von der Webseite, automatisch geupdated.",

--- a/config/tags/piko-neuheiten-2026.json
+++ b/config/tags/piko-neuheiten-2026.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": "1.0.0",
+  "name": "PIKO Neuheiten 2026",
+  "slug": "piko-neuheiten-2026",
+  "description": "Artikel aus dem PIKO-Neuheitenkatalog 2026."
+}


### PR DESCRIPTION
## Summary
- Neuer Taxonomie-Eintrag `piko-neuheiten-2026` in `config/tags/`
- Alle 288 PIKO-Artikel aus dem 2026-Import erhalten den Kampagnen-Tag und `releaseDate: "2026"`

## Test plan
- [x] `npm run validate:data` erfolgreich (699 Artikel, 38 Taxonomie-Dateien)
- [x] Stichprobe: PIKO-Artikel zeigen Tag `piko-neuheiten-2026` und Erscheinungsjahr 2026


Made with [Cursor](https://cursor.com)