### PR TITLE
PIKO: DC-Analog für Gleichstrom ohne werkseitigen Decoder

### DIFF
--- a/articles/piko/21004.json
+++ b/articles/piko/21004.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 195,

--- a/articles/piko/21007.json
+++ b/articles/piko/21007.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 195,

--- a/articles/piko/21024.json
+++ b/articles/piko/21024.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 216,

--- a/articles/piko/21027.json
+++ b/articles/piko/21027.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 216,

--- a/articles/piko/21029.json
+++ b/articles/piko/21029.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 216,

--- a/articles/piko/21044.json
+++ b/articles/piko/21044.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 121,

--- a/articles/piko/21047.json
+++ b/articles/piko/21047.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 121,

--- a/articles/piko/21060.json
+++ b/articles/piko/21060.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 195,

--- a/articles/piko/21080.json
+++ b/articles/piko/21080.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 165,

--- a/articles/piko/21084.json
+++ b/articles/piko/21084.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 165,

--- a/articles/piko/21704.json
+++ b/articles/piko/21704.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 224,

--- a/articles/piko/21710.json
+++ b/articles/piko/21710.json
@@ -15,7 +15,7 @@
     "number": "122",
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 193,

--- a/articles/piko/21722.json
+++ b/articles/piko/21722.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 176,

--- a/articles/piko/21737.json
+++ b/articles/piko/21737.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 189,

--- a/articles/piko/21743.json
+++ b/articles/piko/21743.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 189,

--- a/articles/piko/21746.json
+++ b/articles/piko/21746.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 218,

--- a/articles/piko/21749.json
+++ b/articles/piko/21749.json
@@ -15,7 +15,7 @@
     "number": "3193",
     "livery": "Stern Hafferl",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 230,

--- a/articles/piko/21773.json
+++ b/articles/piko/21773.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 190,

--- a/articles/piko/21776.json
+++ b/articles/piko/21776.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 189,

--- a/articles/piko/21779.json
+++ b/articles/piko/21779.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 191,

--- a/articles/piko/21788.json
+++ b/articles/piko/21788.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 190,

--- a/articles/piko/21791.json
+++ b/articles/piko/21791.json
@@ -15,7 +15,7 @@
     "number": "019",
     "livery": "S-Bahn Leipzig",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 191,

--- a/articles/piko/21797.json
+++ b/articles/piko/21797.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 217,

--- a/articles/piko/21803.json
+++ b/articles/piko/21803.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 218,

--- a/articles/piko/21809.json
+++ b/articles/piko/21809.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 205,

--- a/articles/piko/21824.json
+++ b/articles/piko/21824.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 1002,

--- a/articles/piko/21830.json
+++ b/articles/piko/21830.json
@@ -15,7 +15,7 @@
     "number": "7193",
     "livery": "Medway",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 218,

--- a/articles/piko/21839.json
+++ b/articles/piko/21839.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 230,

--- a/articles/piko/22004.json
+++ b/articles/piko/22004.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 104,

--- a/articles/piko/22007.json
+++ b/articles/piko/22007.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 104,

--- a/articles/piko/22010.json
+++ b/articles/piko/22010.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 104,

--- a/articles/piko/22030.json
+++ b/articles/piko/22030.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "1. Serie mit Logo",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 162,

--- a/articles/piko/22032.json
+++ b/articles/piko/22032.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "2.Serie Navetta",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 162,

--- a/articles/piko/22034.json
+++ b/articles/piko/22034.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "3.Serie mit Schneepflug",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 162,

--- a/articles/piko/22036.json
+++ b/articles/piko/22036.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "1. Serie XMPR",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 162,

--- a/articles/piko/22040.json
+++ b/articles/piko/22040.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 165,

--- a/articles/piko/22044.json
+++ b/articles/piko/22044.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 165,

--- a/articles/piko/22060.json
+++ b/articles/piko/22060.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 188,

--- a/articles/piko/22064.json
+++ b/articles/piko/22064.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 188,

--- a/articles/piko/22080.json
+++ b/articles/piko/22080.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 241,

--- a/articles/piko/27509.json
+++ b/articles/piko/27509.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 193,

--- a/articles/piko/27512.json
+++ b/articles/piko/27512.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "II",
     "luepMm": 193,

--- a/articles/piko/27518.json
+++ b/articles/piko/27518.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 193,

--- a/articles/piko/50740.json
+++ b/articles/piko/50740.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX16",
     "era": "III",
     "luepMm": 123,

--- a/articles/piko/50743.json
+++ b/articles/piko/50743.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX16",
     "era": "II",
     "luepMm": 123,

--- a/articles/piko/50746.json
+++ b/articles/piko/50746.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX16",
     "era": "III",
     "luepMm": 123,

--- a/articles/piko/50749.json
+++ b/articles/piko/50749.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX16",
     "era": "III",
     "luepMm": 123,

--- a/articles/piko/51133.json
+++ b/articles/piko/51133.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 226,

--- a/articles/piko/51149.json
+++ b/articles/piko/51149.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 194,

--- a/articles/piko/51176.json
+++ b/articles/piko/51176.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 230,

--- a/articles/piko/51193.json
+++ b/articles/piko/51193.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 176,

--- a/articles/piko/51423.json
+++ b/articles/piko/51423.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "II",
     "luepMm": 150,

--- a/articles/piko/51449.json
+++ b/articles/piko/51449.json
@@ -15,7 +15,7 @@
     "number": "194",
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 180,

--- a/articles/piko/51466.json
+++ b/articles/piko/51466.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "SKM",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 747,

--- a/articles/piko/51487.json
+++ b/articles/piko/51487.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 214,

--- a/articles/piko/51616.json
+++ b/articles/piko/51616.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 193,

--- a/articles/piko/51618.json
+++ b/articles/piko/51618.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 193,

--- a/articles/piko/51695.json
+++ b/articles/piko/51695.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 232,

--- a/articles/piko/51831.json
+++ b/articles/piko/51831.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 198,

--- a/articles/piko/52077.json
+++ b/articles/piko/52077.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "Saarlandbahn",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 479,

--- a/articles/piko/52100.json
+++ b/articles/piko/52100.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 141,

--- a/articles/piko/52107.json
+++ b/articles/piko/52107.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 202,

--- a/articles/piko/52118.json
+++ b/articles/piko/52118.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "V",
     "luepMm": 224,

--- a/articles/piko/52121.json
+++ b/articles/piko/52121.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "V",
     "luepMm": 224,

--- a/articles/piko/52130.json
+++ b/articles/piko/52130.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 139,

--- a/articles/piko/52139.json
+++ b/articles/piko/52139.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "CTL Rail 4 Chem",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 202,

--- a/articles/piko/52146.json
+++ b/articles/piko/52146.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 199,

--- a/articles/piko/52149.json
+++ b/articles/piko/52149.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 321,

--- a/articles/piko/52310.json
+++ b/articles/piko/52310.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 195,

--- a/articles/piko/52336.json
+++ b/articles/piko/52336.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 139,

--- a/articles/piko/52376.json
+++ b/articles/piko/52376.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 196,

--- a/articles/piko/52380.json
+++ b/articles/piko/52380.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 130,

--- a/articles/piko/52384.json
+++ b/articles/piko/52384.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 130,

--- a/articles/piko/52387.json
+++ b/articles/piko/52387.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 130,

--- a/articles/piko/52584.json
+++ b/articles/piko/52584.json
@@ -15,7 +15,7 @@
     "number": "1001",
     "livery": "Messe Leipzig",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 224,

--- a/articles/piko/52617.json
+++ b/articles/piko/52617.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 212,

--- a/articles/piko/52717.json
+++ b/articles/piko/52717.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 224,

--- a/articles/piko/52876.json
+++ b/articles/piko/52876.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 218,

--- a/articles/piko/52979.json
+++ b/articles/piko/52979.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "bwegt",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 479,

--- a/articles/piko/57408.json
+++ b/articles/piko/57408.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "CityJet",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 221,

--- a/articles/piko/57546.json
+++ b/articles/piko/57546.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 217,

--- a/articles/piko/57568.json
+++ b/articles/piko/57568.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 193,

--- a/articles/piko/57870.json
+++ b/articles/piko/57870.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 217,

--- a/articles/piko/57877.json
+++ b/articles/piko/57877.json
@@ -15,7 +15,7 @@
     "number": "329",
     "livery": "Black Dragons",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 217,

--- a/articles/piko/57976.json
+++ b/articles/piko/57976.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 217,

--- a/articles/piko/58152.json
+++ b/articles/piko/58152.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": null,

--- a/articles/piko/59123.json
+++ b/articles/piko/59123.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 230,

--- a/articles/piko/59167.json
+++ b/articles/piko/59167.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "Railion Logistics NL",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 169,

--- a/articles/piko/59178.json
+++ b/articles/piko/59178.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "Schweerbau",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 180,

--- a/articles/piko/59179.json
+++ b/articles/piko/59179.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "GKB",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 180,

--- a/articles/piko/59277.json
+++ b/articles/piko/59277.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "Cemet",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 164,

--- a/articles/piko/59278.json
+++ b/articles/piko/59278.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "PNI",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 164,

--- a/articles/piko/59370.json
+++ b/articles/piko/59370.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "Northrail",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 169,

--- a/articles/piko/59373.json
+++ b/articles/piko/59373.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "RailCargoGroup",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 169,

--- a/articles/piko/59376.json
+++ b/articles/piko/59376.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "RTS-Swietelsky NL",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 652",
     "era": "VI",
     "luepMm": 169,

--- a/articles/piko/59726.json
+++ b/articles/piko/59726.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 213,

--- a/articles/piko/59762.json
+++ b/articles/piko/59762.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 237,

--- a/articles/piko/59779.json
+++ b/articles/piko/59779.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "CTL Logistics",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 199,

--- a/articles/piko/96316.json
+++ b/articles/piko/96316.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 218,

--- a/articles/piko/96347.json
+++ b/articles/piko/96347.json
@@ -15,7 +15,7 @@
     "number": "277",
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 221,

--- a/articles/piko/96358.json
+++ b/articles/piko/96358.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "V",
     "luepMm": 183,

--- a/articles/piko/96395.json
+++ b/articles/piko/96395.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 183,

--- a/articles/piko/96493.json
+++ b/articles/piko/96493.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 176,

--- a/articles/piko/97504.json
+++ b/articles/piko/97504.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 187,

--- a/articles/piko/97507.json
+++ b/articles/piko/97507.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "III",
     "luepMm": 187,

--- a/articles/piko/97532.json
+++ b/articles/piko/97532.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": "IC",
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "VI",
     "luepMm": 193,

--- a/articles/piko/97540.json
+++ b/articles/piko/97540.json
@@ -15,7 +15,7 @@
     "number": null,
     "livery": null,
     "scale": "H0",
-    "electricSystem": "DC-Digital",
+    "electricSystem": "DC-Analog",
     "decoderInterface": "NEM 658 PluX22",
     "era": "IV",
     "luepMm": 188,

--- a/utils/piko/shop-pdp-parse/piko_shop_parse_pdp.py
+++ b/utils/piko/shop-pdp-parse/piko_shop_parse_pdp.py
@@ -217,27 +217,36 @@ def _operator_to_country(operator: str, era: Optional[str] = None) -> Optional[s
     return mapping.get(op) or mapping.get(operator.strip())
 
 
-def _canonical_electric_system(strom: str, decoder: str, beleuchtung: str) -> Optional[str]:
-    """Richtung Locobox-Roco-Kanon: DC-/AC-Analog bzw. -Digital."""
-    s = (strom or "").lower()
-    hint = f"{decoder} {beleuchtung}".lower()
-    digital = any(
-        x in hint
-        for x in (
-            "plux",
-            "dcc",
-            "next18",
-            "nem 65",
-            "nem658",
-            "decoder",
-            "dss",
-            "digital schaltbar",
-            "digital-schaltbar",
-        )
-    ) or ("digital" in s and "strom" in s)
-    if "gleichstrom" in s:
-        return "DC-Digital" if digital else "DC-Analog"
-    if "wechselstrom" in s:
+def _description_has_installed_decoder(description: str) -> bool:
+    """
+    PIKO Gleichstrom: nur mit werkseitigem Decoder bzw. Sound-Variante als DC-Digital.
+    DCC-Schnittstelle, nachrüstbarer Sound oder «mit PluX22 Decoder» bei Beleuchtung
+    zählen nicht (das ist die DC-Analog-Stufe).
+    """
+    d = description or ""
+    first = d.split("\n", 1)[0]
+    if re.search(
+        r"\bSound[\s-]*(E-|Diesel|E-Trieb|Trieb|Elektro|Zweikraft)",
+        first,
+        re.I,
+    ):
+        return True
+    if "Sound ja/nein: ja" in d:
+        return True
+    if "Verbauter Decoder:" in d:
+        return True
+    if "Sound: PIKO Sound-Decoder werkseitig" in d:
+        return True
+    return False
+
+
+def _canonical_electric_system_from_description(description: str) -> Optional[str]:
+    """Richtung Locobox-Kanon: DC-/AC-Analog bzw. -Digital aus Shop-Beschreibung."""
+    d = description or ""
+    if "Stromsystem: Gleichstrom" in d:
+        return "DC-Digital" if _description_has_installed_decoder(d) else "DC-Analog"
+    if "Stromsystem: Wechselstrom" in d:
+        digital = _description_has_installed_decoder(d) or "Digitale Schnittstelle:" in d
         return "AC-Digital" if digital else "AC-Analog"
     return None
 
@@ -322,14 +331,7 @@ def _apply_attributes_to_model(attrs: dict[str, str]) -> dict[str, Any]:
         model["operator"] = op
         model["country"] = _operator_to_country(op, model.get("era"))
 
-    strom = attrs.get("Stromsystem", "").strip()
     dec = attrs.get("Digitale Schnittstelle", "").strip()
-    bel = attrs.get("(Innen-)Beleuchtung", "").strip()
-    if not bel:
-        bel = attrs.get("Beleuchtung", "").strip()
-    es = _canonical_electric_system(strom, dec, bel)
-    if es:
-        model["electricSystem"] = es
     if dec:
         model["decoderInterface"] = dec
 
@@ -401,6 +403,10 @@ def parse_html(
             if lines:
                 parts.append("\n".join(lines[:18]))
         description = "\n\n".join(p for p in parts if p).strip()
+
+    es = _canonical_electric_system_from_description(description)
+    if es:
+        model["electricSystem"] = es
 
     payload = {
         "schemaVersion": "1.0.0",

--- a/utils/piko/shop-pdp-parse/test_piko_shop_parse_pdp.py
+++ b/utils/piko/shop-pdp-parse/test_piko_shop_parse_pdp.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Tests für PIKO Shop-Parser (Stromsystem aus Beschreibung)."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "shop-pdp-parse" / "piko_shop_parse_pdp.py"
+_spec = importlib.util.spec_from_file_location("piko_shop_parse_pdp", _SCRIPT)
+assert _spec and _spec.loader
+m = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(m)
+
+
+class TestPikoElectricSystem(unittest.TestCase):
+    def test_dc_analog_expert_plux_without_builtin_decoder(self) -> None:
+        desc = (
+            "E-Lok BR 184.1 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\n"
+            "Stromsystem: Gleichstrom\n"
+            "Digitale Schnittstelle: NEM 658 PluX22\n"
+            "(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\n"
+            "Sound: PIKO Sound-Decoder nachrüstbar #56644"
+        )
+        self.assertEqual(m._canonical_electric_system_from_description(desc), "DC-Analog")
+
+    def test_dc_digital_sound_variant(self) -> None:
+        desc = (
+            "Sound-E-Lok BR 184.1 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\n"
+            "Sound ja/nein: ja\n"
+            "Stromsystem: Gleichstrom\n"
+            "Verbauter Decoder: PluX22 Sounddecoder\n"
+            "Sound: PIKO Sound-Decoder werkseitig ausgerüstet"
+        )
+        self.assertEqual(m._canonical_electric_system_from_description(desc), "DC-Digital")
+
+    def test_dc_analog_smartline_nem652(self) -> None:
+        desc = (
+            "E-Lok BR 185 Beacon VI Modelleisenbahn kaufen | PIKO Webshop\n\n"
+            "Stromsystem: Gleichstrom\n"
+            "Digitale Schnittstelle: NEM 652"
+        )
+        self.assertEqual(m._canonical_electric_system_from_description(desc), "DC-Analog")
+
+    def test_ac_digital_with_builtin_decoder(self) -> None:
+        desc = (
+            "E-Lok BR 185 Beacon VI Wechselstromversion Modelleisenbahn kaufen | PIKO Webshop\n\n"
+            "Stromsystem: Wechselstrom\n"
+            "Digitale Schnittstelle: NEM 652\n"
+            "Verbauter Decoder: 8-polig"
+        )
+        self.assertEqual(m._canonical_electric_system_from_description(desc), "AC-Digital")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 107 PIKO-Artikel von `DC-Digital` auf `DC-Analog` korrigiert (nur DCC-Schnittstelle / nachrüstbarer Sound, kein werkseitiger Decoder)
- Parser leitet `electricSystem` aus der Shop-Beschreibung ab: DC-Digital nur bei Sound-Variante oder `Verbauter Decoder`
- Tests für Expert-, Sound- und Smartline-Fälle ergänzt

## Test plan
- [x] `python3 -m unittest utils.piko.shop-pdp-parse.test_piko_shop_parse_pdp`
- [x] `npm run validate:data`
- [x] Stichprobe: `21004` → DC-Analog, `21005` → DC-Digital, `57870` → DC-Analog


Made with [Cursor](https://cursor.com)