### PR TITLE
PIKO Neuheiten 2025: Shop-Import und Kampagnen-Tag

### DIFF
--- a/articles/piko/21002.json
+++ b/articles/piko/21002.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21002",
+  "manufacturer": "PIKO",
+  "articleNumber": "21002",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 325.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR E410",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 195,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR E410 DB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21002\nEAN: 4015615210023\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-e410-db-iii,-inkl.-piko-sound-decoder-45293.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45293/thumbs/56068_401089.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21044.json
+++ b/articles/piko/21044.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1067",
-    "number": null,
+    "type": "Rh",
+    "number": "1067",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/21045.json
+++ b/articles/piko/21045.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1067",
-    "number": null,
+    "type": "Rh",
+    "number": "1067",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/21046.json
+++ b/articles/piko/21046.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1067",
-    "number": null,
+    "type": "Rh",
+    "number": "1067",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/21047.json
+++ b/articles/piko/21047.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1067",
-    "number": null,
+    "type": "Rh",
+    "number": "1067",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/21048.json
+++ b/articles/piko/21048.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1067",
-    "number": null,
+    "type": "Rh",
+    "number": "1067",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/21049.json
+++ b/articles/piko/21049.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1067",
-    "number": null,
+    "type": "Rh",
+    "number": "1067",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/21695.json
+++ b/articles/piko/21695.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21695",
+  "manufacturer": "PIKO",
+  "articleNumber": "21695",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 235.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 120",
+    "number": "005",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok 120 005 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21695\nEAN: 4015615216957\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 221\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56530\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-120-005-db-iv-44684.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44684/thumbs/56070_413983.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21696.json
+++ b/articles/piko/21696.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21696",
+  "manufacturer": "PIKO",
+  "articleNumber": "21696",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 345.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 120",
+    "number": "005",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok 120 005 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21696\nEAN: 4015615216964\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 221\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-120-005-db-iv,-inkl.-piko-sound-decoder-44685.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44685/thumbs/56071_409538.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21697.json
+++ b/articles/piko/21697.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21697",
+  "manufacturer": "PIKO",
+  "articleNumber": "21697",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 345.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 120",
+    "number": "005",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 221,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok 120 005 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21697\nEAN: 4015615216971\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 221\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-120-005-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-44686.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44686/thumbs/56072_406886.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21698.json
+++ b/articles/piko/21698.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21698",
+  "manufacturer": "PIKO",
+  "articleNumber": "21698",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 219.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DD",
+    "operator": "DR",
+    "type": "BR 143",
+    "number": null,
+    "livery": "S-Bahn",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 191,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR 143 S-Bahn DR IV-V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21698\nEAN: 4015615216988\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56558\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-143-s-bahn-dr-iv-v-44922.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44922/thumbs/54907_402676.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21699.json
+++ b/articles/piko/21699.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21699",
+  "manufacturer": "PIKO",
+  "articleNumber": "21699",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 334.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DD",
+    "operator": "DR",
+    "type": "BR 143",
+    "number": null,
+    "livery": "S-Bahn",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 191,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 143 S-Bahn DR IV-V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21699\nEAN: 4015615216995\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DR\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-143-s-bahn-dr-iv-v,-inkl.-piko-sound-decoder-44923.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44923/thumbs/54908_437144.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21700.json
+++ b/articles/piko/21700.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21700",
+  "manufacturer": "PIKO",
+  "articleNumber": "21700",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 334.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DD",
+    "operator": "DR",
+    "type": "BR 143",
+    "number": null,
+    "livery": "S-Bahn",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 191,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 143 S-Bahn DR IV-V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21700\nEAN: 4015615217008\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DR\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 191\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-143-s-bahn-dr-iv-v-wechselstromversion,-inkl.-piko-sound-decoder-44924.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44924/thumbs/54909_408882.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21702.json
+++ b/articles/piko/21702.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21702",
+  "manufacturer": "PIKO",
+  "articleNumber": "21702",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 319.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 140",
+    "number": null,
+    "livery": "Press",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 190,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 140 Press VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21702\nEAN: 4015615217022\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 190\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Digital schaltbare Maschinenraumbeleuchtung",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-140-press-vi,-inkl.-piko-sound-decoder-45347.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45347/thumbs/56395_453388.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21702.json
+++ b/articles/piko/21702.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 140",
     "number": null,

--- a/articles/piko/21707.json
+++ b/articles/piko/21707.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 187",
     "number": null,

--- a/articles/piko/21707.json
+++ b/articles/piko/21707.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21707",
+  "manufacturer": "PIKO",
+  "articleNumber": "21707",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 204.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 187",
+    "number": null,
+    "livery": "HSL",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR 187 HSL VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21707\nEAN: 4015615217077\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56545\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-187-hsl-vi-44925.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44925/thumbs/54910_437820.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21708.json
+++ b/articles/piko/21708.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21708",
+  "manufacturer": "PIKO",
+  "articleNumber": "21708",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 314.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 187",
+    "number": null,
+    "livery": "HSL",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 187 HSL VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21708\nEAN: 4015615217084\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-187-hsl-vi,-inkl.-piko-sound-decoder-44926.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44926/thumbs/54911_435533.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21708.json
+++ b/articles/piko/21708.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 187",
     "number": null,

--- a/articles/piko/21709.json
+++ b/articles/piko/21709.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21709",
+  "manufacturer": "PIKO",
+  "articleNumber": "21709",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 314.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 187",
+    "number": null,
+    "livery": "HSL",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 187 HSL VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21709\nEAN: 4015615217091\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-187-hsl-vi-wechselstromversion,-inkl.-piko-sound-decoder-44927.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44927/thumbs/54912_425753.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21709.json
+++ b/articles/piko/21709.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 187",
     "number": null,

--- a/articles/piko/21713.json
+++ b/articles/piko/21713.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21713",
+  "manufacturer": "PIKO",
+  "articleNumber": "21713",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 219.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 193",
+    "number": null,
+    "livery": "Alpha Trains",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrolok Vectron BR 193 Alpha Trains VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21713\nEAN: 4015615217138\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56544\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/elektrolok-vectron-br-193-alpha-trains-vi-44931.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44931/thumbs/54913_424778.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21713.json
+++ b/articles/piko/21713.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 193",
     "number": null,

--- a/articles/piko/21714.json
+++ b/articles/piko/21714.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 193",
     "number": null,

--- a/articles/piko/21714.json
+++ b/articles/piko/21714.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21714",
+  "manufacturer": "PIKO",
+  "articleNumber": "21714",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 335.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 193",
+    "number": null,
+    "livery": "Alpha Trains",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Elektrolok Vectron BR 193 Alpha Trains VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21714\nEAN: 4015615217145\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-elektrolok-vectron-br-193-alpha-trains-vi,-inkl.-piko-sound-decoder-44932.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44932/thumbs/54914_425596.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21715.json
+++ b/articles/piko/21715.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21715",
+  "manufacturer": "PIKO",
+  "articleNumber": "21715",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 335.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 193",
+    "number": null,
+    "livery": "Alpha Trains",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Elektrolok Vectron BR 193 Alpha Trains VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21715\nEAN: 4015615217152\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-elektrolok-vectron-br-193-alpha-trains-vi-wechselstromversion,-inkl.-piko-sound-decoder-44933.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44933/thumbs/54915_425590.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21715.json
+++ b/articles/piko/21715.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 193",
     "number": null,

--- a/articles/piko/21717.json
+++ b/articles/piko/21717.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21717",
+  "manufacturer": "PIKO",
+  "articleNumber": "21717",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 329.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 112",
+    "number": "311",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 189,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok 112 311 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21717\nEAN: 4015615217176\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-112-311-db-iv,-inkl.-piko-sound-decoder-44754.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44754/thumbs/56665_471371.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21718.json
+++ b/articles/piko/21718.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21718",
+  "manufacturer": "PIKO",
+  "articleNumber": "21718",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 329.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 112",
+    "number": "311",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 189,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok 112 311 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21718\nEAN: 4015615217183\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-112-311-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-44755.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44755/thumbs/56666_471385.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21722.json
+++ b/articles/piko/21722.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1041",
-    "number": null,
+    "type": "Rh",
+    "number": "1041",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/21723.json
+++ b/articles/piko/21723.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1041",
-    "number": null,
+    "type": "Rh",
+    "number": "1041",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/21724.json
+++ b/articles/piko/21724.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1041",
-    "number": null,
+    "type": "Rh",
+    "number": "1041",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/21725.json
+++ b/articles/piko/21725.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21725",
+  "manufacturer": "PIKO",
+  "articleNumber": "21725",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 235.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "Rh",
+    "number": "1010",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 205,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok Rh 1010 ÖBB V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21725\nEAN: 4015615217251\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 205\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56563\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-rh-1010-oebb-v-44773.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44773/thumbs/56073_406662.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21726.json
+++ b/articles/piko/21726.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21726",
+  "manufacturer": "PIKO",
+  "articleNumber": "21726",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 345.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "Rh",
+    "number": "1010",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 205,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok Rh 1010 ÖBB V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21726\nEAN: 4015615217268\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 205\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1010-oebb-v,-inkl.-piko-sound-decoder-45008.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45008/thumbs/56074_412695.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21727.json
+++ b/articles/piko/21727.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21727",
+  "manufacturer": "PIKO",
+  "articleNumber": "21727",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 345.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "Rh",
+    "number": "1010",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 205,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok Rh 1010 ÖBB V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21727\nEAN: 4015615217275\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 205\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-1010-oebb-v-wechselstromversion,-inkl.-piko-sound-decoder-45011.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45011/thumbs/56075_409866.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21731.json
+++ b/articles/piko/21731.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21731",
+  "manufacturer": "PIKO",
+  "articleNumber": "21731",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 199.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 187",
+    "number": null,
+    "livery": "WLC",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR 187 WLC VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21731\nEAN: 4015615217312\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56545\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-187-wlc-vi-44929.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44929/thumbs/57409_494960.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21731.json
+++ b/articles/piko/21731.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "PL",
     "operator": "Privatbahn",
     "type": "BR 187",
     "number": null,

--- a/articles/piko/21732.json
+++ b/articles/piko/21732.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21732",
+  "manufacturer": "PIKO",
+  "articleNumber": "21732",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 309.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 187",
+    "number": null,
+    "livery": "WLC",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 187 WLC VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21732\nEAN: 4015615217329\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-187-wlc-vi,-inkl.-piko-sound-decoder-44930.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44930/thumbs/57410_494990.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21732.json
+++ b/articles/piko/21732.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "PL",
     "operator": "Privatbahn",
     "type": "BR 187",
     "number": null,

--- a/articles/piko/21733.json
+++ b/articles/piko/21733.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21733",
+  "manufacturer": "PIKO",
+  "articleNumber": "21733",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 309.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 187",
+    "number": null,
+    "livery": "WLC",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 217,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 187 WLC VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21733\nEAN: 4015615217336\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 217\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-187-wlc-vi-wechselstromversion,-inkl.-piko-sound-decoder-44928.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44928/thumbs/57411_495387.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21733.json
+++ b/articles/piko/21733.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "PL",
     "operator": "Privatbahn",
     "type": "BR 187",
     "number": null,

--- a/articles/piko/21737.json
+++ b/articles/piko/21737.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "CZ",
     "operator": "CD",
-    "type": "Rh 230",
-    "number": null,
+    "type": "Rh",
+    "number": "230",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/21738.json
+++ b/articles/piko/21738.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "CZ",
     "operator": "CD",
-    "type": "Rh 230",
-    "number": null,
+    "type": "Rh",
+    "number": "230",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/21739.json
+++ b/articles/piko/21739.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "CZ",
     "operator": "CD",
-    "type": "Rh 230",
-    "number": null,
+    "type": "Rh",
+    "number": "230",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/21740.json
+++ b/articles/piko/21740.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21740",
+  "manufacturer": "PIKO",
+  "articleNumber": "21740",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 275.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CS",
+    "operator": "CSD",
+    "type": "S 489.0",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 189,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok S 489.0 CSD IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21740\nEAN: 4015615217404\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56586\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-s-489.0-csd-iv-45063.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45063/thumbs/56076_411852.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21741.json
+++ b/articles/piko/21741.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21741",
+  "manufacturer": "PIKO",
+  "articleNumber": "21741",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 385.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CS",
+    "operator": "CSD",
+    "type": "S 489.0",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 189,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok S 489.0 CSD IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21741\nEAN: 4015615217411\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-s-489.0-csd-iv,-inkl.-piko-sound-decoder-45074.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45074/thumbs/56077_409746.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21742.json
+++ b/articles/piko/21742.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21742",
+  "manufacturer": "PIKO",
+  "articleNumber": "21742",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 385.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CS",
+    "operator": "CSD",
+    "type": "S 489.0",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 189,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok S 489.0 CSD IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21742\nEAN: 4015615217428\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CSD\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-s-489.0-csd-iv-wechselstromversion,-inkl.-piko-sound-decoder-45075.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45075/thumbs/56078_411489.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21743.json
+++ b/articles/piko/21743.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "CZ",
     "operator": "CD",
-    "type": "Rh 240",
-    "number": null,
+    "type": "Rh",
+    "number": "240",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/21744.json
+++ b/articles/piko/21744.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "CZ",
     "operator": "CD",
-    "type": "Rh 240",
-    "number": null,
+    "type": "Rh",
+    "number": "240",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/21745.json
+++ b/articles/piko/21745.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "CZ",
     "operator": "CD",
-    "type": "Rh 240",
-    "number": null,
+    "type": "Rh",
+    "number": "240",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/21752.json
+++ b/articles/piko/21752.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21752",
+  "manufacturer": "PIKO",
+  "articleNumber": "21752",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 284.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 440",
+    "number": null,
+    "livery": "Bwegt",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 818,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrotriebwagen BR 440 Bwegt DB AG VI 4-tlg. Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21752\nEAN: 4015615217527\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 818\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\n(Innen-)Beleuchtung: Innenbeleuchtung nachrüstbar mit 2x #56145 + 2x #56146\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56614\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/elektrotriebwagen-br-440-bwegt-db-ag-vi-4-tlg.-45216.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45216/thumbs/56079_412705.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21753.json
+++ b/articles/piko/21753.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21753",
+  "manufacturer": "PIKO",
+  "articleNumber": "21753",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 394.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 440",
+    "number": null,
+    "livery": "Bwegt",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 818,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Elektrotriebwagen BR 440 Bwegt DB AG VI 4-tlg., inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21753\nEAN: 4015615217534\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 818\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Innenbeleuchtung nachrüstbar mit 2x #56145 + 2x #56146\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-elektrotriebwagen-br-440-bwegt-db-ag-vi-4-tlg.,-inkl.-piko-sound-decoder-45217.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45217/thumbs/56080_406944.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/21754.json
+++ b/articles/piko/21754.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-21754",
+  "manufacturer": "PIKO",
+  "articleNumber": "21754",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 394.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 440",
+    "number": null,
+    "livery": "Bwegt",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 831,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Elektrotriebwagen BR 440 Bwegt VI 4-tlg Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 21754\nEAN: 4015615217541\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 831\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Innenbeleuchtung nachrüstbar mit 2x #56145 + 2x #56146\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-elektrotriebwagen-br-440-bwegt-vi-4-tlg-wechselstrom,-inkl.-piko-sound-decoder-45218.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45218/thumbs/56081_411501.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/22004.json
+++ b/articles/piko/22004.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 500",
-    "number": null,
+    "type": "Rh",
+    "number": "500",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/22005.json
+++ b/articles/piko/22005.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 500",
-    "number": null,
+    "type": "Rh",
+    "number": "500",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/22006.json
+++ b/articles/piko/22006.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 500",
-    "number": null,
+    "type": "Rh",
+    "number": "500",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/22007.json
+++ b/articles/piko/22007.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "Privatbahn",
-    "type": "Rh 500",
-    "number": null,
+    "type": "Rh",
+    "number": "500",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/22008.json
+++ b/articles/piko/22008.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "Privatbahn",
-    "type": "Rh 500",
-    "number": null,
+    "type": "Rh",
+    "number": "500",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/22009.json
+++ b/articles/piko/22009.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "Privatbahn",
-    "type": "Rh 500",
-    "number": null,
+    "type": "Rh",
+    "number": "500",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/22010.json
+++ b/articles/piko/22010.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "DK",
     "operator": "DSB",
-    "type": "Rh 600",
-    "number": null,
+    "type": "Rh",
+    "number": "600",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/22011.json
+++ b/articles/piko/22011.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "DK",
     "operator": "DSB",
-    "type": "Rh 600",
-    "number": null,
+    "type": "Rh",
+    "number": "600",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/22012.json
+++ b/articles/piko/22012.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "DK",
     "operator": "DSB",
-    "type": "Rh 600",
-    "number": null,
+    "type": "Rh",
+    "number": "600",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/27506.json
+++ b/articles/piko/27506.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-27506",
+  "manufacturer": "PIKO",
+  "articleNumber": "27506",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 339.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "GTW 2/6",
+    "number": null,
+    "livery": "Stadler",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 652",
+    "era": "V",
+    "luepMm": 453,
+    "minRadiusMm": 358
+  },
+  "description": "Elektrotriebzug GTW 2/6 \"Stadler\" S-Bahn Bern RM V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27506\nEAN: 4015615275060\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 453\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\n(Innen-)Beleuchtung: Innenbeleuchtung nachrüstbar mit 2 #56139\nSound: PIKO Sound-Decoder nachrüstbar #56617\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/elektrotriebzug-gtw-2-6-stadler-s-bahn-bern-rm-v-45465.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45465/thumbs/56527_456284.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/27506.json
+++ b/articles/piko/27506.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "CH",
     "operator": "Privatbahn",
     "type": "GTW 2/6",
     "number": null,

--- a/articles/piko/27507.json
+++ b/articles/piko/27507.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-27507",
+  "manufacturer": "PIKO",
+  "articleNumber": "27507",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CH",
+    "operator": "SBB",
+    "type": "GTW 2/6",
+    "number": null,
+    "livery": "Stadler",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "V",
+    "luepMm": 453,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Elektrotriebzug GTW 2/6 \"Stadler\" S-Bahn Bern RM V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27507\nEAN: 4015615275077\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 453\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Innenbeleuchtung nachrüstbar mit 2 #56139\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-elektrotriebzug-gtw-2-6-stadler-s-bahn-bern-rm-v,-inkl.-piko-sound-decoder-45468.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45468/thumbs/56528_422709.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/27508.json
+++ b/articles/piko/27508.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-27508",
+  "manufacturer": "PIKO",
+  "articleNumber": "27508",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CH",
+    "operator": "SBB",
+    "type": "GTW 2/6",
+    "number": null,
+    "livery": "Stadler",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "V",
+    "luepMm": 453,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Elektrotriebzug GTW 2/6 \"Stadler\" S-Bahn Bern RM V Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 27508\nEAN: 4015615275084\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: SBB\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 453\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Innenbeleuchtung nachrüstbar mit 2 #56139\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-elektrotriebzug-gtw-2-6-stadler-s-bahn-bern-rm-v-wechselstrom,-inkl.-piko-sound-decoder-45467.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45467/thumbs/56529_451089.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/27509.json
+++ b/articles/piko/27509.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "BE",
     "operator": "SNCB",
-    "type": "Rh 7000",
-    "number": null,
+    "type": "Rh",
+    "number": "7000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/27510.json
+++ b/articles/piko/27510.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "BE",
     "operator": "SNCB",
-    "type": "Rh 7000",
-    "number": null,
+    "type": "Rh",
+    "number": "7000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/27511.json
+++ b/articles/piko/27511.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "BE",
     "operator": "SNCB",
-    "type": "Rh 7000",
-    "number": null,
+    "type": "Rh",
+    "number": "7000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/50730.json
+++ b/articles/piko/50730.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-50730",
+  "manufacturer": "PIKO",
+  "articleNumber": "50730",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 259.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 91.3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX16",
+    "era": "III",
+    "luepMm": 123,
+    "minRadiusMm": 422
+  },
+  "description": "Dampflok BR 91.3 DB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50730\nEAN: 4015615507307\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder nachrüstbar #56643\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/dampflok-br-91.3-db-iii-45006.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_45006/thumbs/55980_409745.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/50732.json
+++ b/articles/piko/50732.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-50732",
+  "manufacturer": "PIKO",
+  "articleNumber": "50732",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 369.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 91.3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX16",
+    "era": "III",
+    "luepMm": 123,
+    "minRadiusMm": 422
+  },
+  "description": "Sound-Dampflok BR 91.3 DB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50732\nEAN: 4015615507321\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-91.3-db-iii,-inkl.-piko-sound-decoder-45009.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45009/thumbs/55981_409747.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/50733.json
+++ b/articles/piko/50733.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-50733",
+  "manufacturer": "PIKO",
+  "articleNumber": "50733",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 369.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 91.3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX16",
+    "era": "III",
+    "luepMm": 123,
+    "minRadiusMm": 422
+  },
+  "description": "Sound-Dampflok BR 91.3 DB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50733\nEAN: 4015615507338\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-br-91.3-db-iii-wechselstromversion,-inkl.-piko-sound-decoder-45010.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45010/thumbs/55982_451850.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/50737.json
+++ b/articles/piko/50737.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-50737",
+  "manufacturer": "PIKO",
+  "articleNumber": "50737",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 259.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "TKi3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX16",
+    "era": "III",
+    "luepMm": 123,
+    "minRadiusMm": 422
+  },
+  "description": "Dampflok TKi3 PKP III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50737\nEAN: 4015615507376\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder nachrüstbar #56643\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/dampflok-tki3-pkp-iii-45012.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_45012/thumbs/58954_519826.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/50738.json
+++ b/articles/piko/50738.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-50738",
+  "manufacturer": "PIKO",
+  "articleNumber": "50738",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 369.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "TKi3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX16",
+    "era": "III",
+    "luepMm": 123,
+    "minRadiusMm": 422
+  },
+  "description": "Sound-Dampflok TKi3 PKP III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50738\nEAN: 4015615507383\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-tki3-pkp-iii,-inkl.-piko-sound-decoder-45013.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45013/thumbs/58955_519862.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/50739.json
+++ b/articles/piko/50739.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-50739",
+  "manufacturer": "PIKO",
+  "articleNumber": "50739",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 369.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "TKi3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX16",
+    "era": "III",
+    "luepMm": 123,
+    "minRadiusMm": 422
+  },
+  "description": "Sound-Dampflok TKi3 PKP III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 50739\nEAN: 4015615507390\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: PKP\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 123\nMindestradius [mm]: 422\nDigitale Schnittstelle: NEM 658 PluX16\nVerbauter Decoder: PluX16 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dampflok-tki3-pkp-iii-wechselstromversion,-inkl.-piko-sound-decoder-45014.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45014/thumbs/58956_519887.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/50740.json
+++ b/articles/piko/50740.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 691",
-    "number": null,
+    "type": "Rh",
+    "number": "691",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/50741.json
+++ b/articles/piko/50741.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 691",
-    "number": null,
+    "type": "Rh",
+    "number": "691",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/50742.json
+++ b/articles/piko/50742.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 691",
-    "number": null,
+    "type": "Rh",
+    "number": "691",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/50746.json
+++ b/articles/piko/50746.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 75",
-    "number": null,
+    "type": "Rh",
+    "number": "75",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/50747.json
+++ b/articles/piko/50747.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 75",
-    "number": null,
+    "type": "Rh",
+    "number": "75",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/50748.json
+++ b/articles/piko/50748.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 75",
-    "number": null,
+    "type": "Rh",
+    "number": "75",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/51149.json
+++ b/articles/piko/51149.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1018",
-    "number": null,
+    "type": "Rh",
+    "number": "1018",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/51150.json
+++ b/articles/piko/51150.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1018",
-    "number": null,
+    "type": "Rh",
+    "number": "1018",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/51151.json
+++ b/articles/piko/51151.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "AT",
     "operator": "ÖBB",
-    "type": "Rh 1018",
-    "number": null,
+    "type": "Rh",
+    "number": "1018",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/51167.json
+++ b/articles/piko/51167.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51167",
+  "manufacturer": "PIKO",
+  "articleNumber": "51167",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 215.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "Privatbahn",
+    "type": "BR 248",
+    "number": null,
+    "livery": "Northrail",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Zweikraftlok \"dual mode\" BR 248 Northrail VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51167\nEAN: 4015615511670\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56631\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/zweikraftlok-dual-mode-br-248-northrail-vi-44253.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_z/oart_44253/thumbs/54457_445454.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51168.json
+++ b/articles/piko/51168.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51168",
+  "manufacturer": "PIKO",
+  "articleNumber": "51168",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 325.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "Privatbahn",
+    "type": "BR 248",
+    "number": null,
+    "livery": "Northrail",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Zweikraftlok \"dual mode\" BR 248 Northrail VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51168\nEAN: 4015615511687\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-northrail-vi,-inkl.-piko-sound-decoder-44254.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44254/thumbs/54458_446648.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51169.json
+++ b/articles/piko/51169.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51169",
+  "manufacturer": "PIKO",
+  "articleNumber": "51169",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 325.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "Privatbahn",
+    "type": "BR 248",
+    "number": null,
+    "livery": "Northrail",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Zweikraftlok \"dual mode\" BR 248 Northrail VI Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51169\nEAN: 4015615511694\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-northrail-vi-wechselstrom,-inkl.-piko-sound-decoder-44255.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44255/thumbs/54459_439405.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51173.json
+++ b/articles/piko/51173.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51173",
+  "manufacturer": "PIKO",
+  "articleNumber": "51173",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 215.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "BR 248",
+    "number": null,
+    "livery": "CD Cargo",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Zweikraftlok \"dual mode\" BR 248 CD Cargo VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51173\nEAN: 4015615511731\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56631\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/zweikraftlok-dual-mode-br-248-cd-cargo-vi-45042.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45042/thumbs/55758_447129.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51174.json
+++ b/articles/piko/51174.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51174",
+  "manufacturer": "PIKO",
+  "articleNumber": "51174",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 325.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "BR 248",
+    "number": null,
+    "livery": "CD Cargo",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Zweikraftlok \"dual mode\" BR 248 CD Cargo VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51174\nEAN: 4015615511748\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-cd-cargo-vi,-inkl.-piko-sound-decoder-45048.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45048/thumbs/55759_419872.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51175.json
+++ b/articles/piko/51175.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51175",
+  "manufacturer": "PIKO",
+  "articleNumber": "51175",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 325.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "BR 248",
+    "number": null,
+    "livery": "CD Cargo",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Zweikraftlok \"dual mode\" BR 248 CD Cargo VI Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51175\nEAN: 4015615511755\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-cd-cargo-vi-wechselstrom,-inkl.-piko-sound-decoder-45049.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45049/thumbs/55760_440272.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51190.json
+++ b/articles/piko/51190.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51190",
+  "manufacturer": "PIKO",
+  "articleNumber": "51190",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 259.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR E44 W",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 176,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR E44 W DB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51190\nEAN: 4015615511908\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56634\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-e44-w-db-iii-45021.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45021/thumbs/56681_471482.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51191.json
+++ b/articles/piko/51191.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51191",
+  "manufacturer": "PIKO",
+  "articleNumber": "51191",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 369.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR E44 W",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 176,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR E44 W DB III , inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51191\nEAN: 4015615511915\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-e44-w-db-iii-,-inkl.-piko-sound-decoder-45022.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45022/thumbs/56682_471757.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51192.json
+++ b/articles/piko/51192.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51192",
+  "manufacturer": "PIKO",
+  "articleNumber": "51192",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 369.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR E44 W",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 176,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR E44 W DB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51192\nEAN: 4015615511922\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 176\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-e44-w-db-iii-wechselstromversion,-inkl.-piko-sound-decoder-45023.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45023/thumbs/56683_471938.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51446.json
+++ b/articles/piko/51446.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51446",
+  "manufacturer": "PIKO",
+  "articleNumber": "51446",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 255.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "HU",
+    "operator": "MAV",
+    "type": "V 43.3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 180,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok V 43.3 MAV V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51446\nEAN: 4015615514466\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56598\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-v-43.3-mav-v-44661.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44661/thumbs/56090_442934.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51447.json
+++ b/articles/piko/51447.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51447",
+  "manufacturer": "PIKO",
+  "articleNumber": "51447",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 365.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "HU",
+    "operator": "MAV",
+    "type": "V 43.3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 180,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok V 43.3 MAV V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51447\nEAN: 4015615514473\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-v-43.3-mav-v,-inkl.-piko-sound-decoder-44662.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44662/thumbs/56091_495694.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51448.json
+++ b/articles/piko/51448.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51448",
+  "manufacturer": "PIKO",
+  "articleNumber": "51448",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 365.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "HU",
+    "operator": "MAV",
+    "type": "V 43.3",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 180,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok V 43.3 MAV V Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51448\nEAN: 4015615514480\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: MAV\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-v-43.3-mav-v-wechselstromversion,-inkl.-piko-sound-decoder-44663.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44663/thumbs/56092_495703.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51462.json
+++ b/articles/piko/51462.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51462",
+  "manufacturer": "PIKO",
+  "articleNumber": "51462",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 439.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "EN 57",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 747,
+    "minRadiusMm": 358
+  },
+  "description": "E-Triebzug EN 57 PKP V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51462\nEAN: 4015615514626\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 747\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nKupplung: NEM Schacht + Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-triebzug-en-57-pkp-v-45005.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45005/thumbs/56093_406725.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51463.json
+++ b/articles/piko/51463.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51463",
+  "manufacturer": "PIKO",
+  "articleNumber": "51463",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 549.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "EN 57",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 747,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Triebzug EN 57 PKP V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51463\nEAN: 4015615514633\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 747\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-triebzug-en-57-pkp-v,-inkl.-piko-sound-decoder-45004.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45004/thumbs/56094_412859.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51497.json
+++ b/articles/piko/51497.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51497",
+  "manufacturer": "PIKO",
+  "articleNumber": "51497",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 249.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 117",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 183,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR 117 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51497\nEAN: 4015615514978\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56604\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-117-db-iv-44571.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44571/thumbs/54557_423887.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51498.json
+++ b/articles/piko/51498.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51498",
+  "manufacturer": "PIKO",
+  "articleNumber": "51498",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 117",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 183,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 117 DB IV , inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51498\nEAN: 4015615514985\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-117-db-iv-,-inkl.-piko-sound-decoder-44572.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44572/thumbs/54558_432362.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51499.json
+++ b/articles/piko/51499.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51499",
+  "manufacturer": "PIKO",
+  "articleNumber": "51499",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 117",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 183,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 117 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51499\nEAN: 4015615514992\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-117-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-44573.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44573/thumbs/54559_447182.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51537.json
+++ b/articles/piko/51537.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51537",
+  "manufacturer": "PIKO",
+  "articleNumber": "51537",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 199.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 141",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 180,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR 141 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51537\nEAN: 4015615515371\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56546\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-141-db-iv-45343.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45343/thumbs/58884_518096.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51538.json
+++ b/articles/piko/51538.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51538",
+  "manufacturer": "PIKO",
+  "articleNumber": "51538",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 313.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 141",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 180,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 141 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51538\nEAN: 4015615515388\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-141-db-iv,-inkl.-piko-sound-decoder-45344.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45344/thumbs/58885_518076.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51539.json
+++ b/articles/piko/51539.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51539",
+  "manufacturer": "PIKO",
+  "articleNumber": "51539",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 313.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 141",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 180,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 141 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51539\nEAN: 4015615515395\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 180\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-141-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-45345.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45345/thumbs/58886_518075.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51657.json
+++ b/articles/piko/51657.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51657",
+  "manufacturer": "PIKO",
+  "articleNumber": "51657",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 219.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 150",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 224,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR 150 DB IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51657\nEAN: 4015615516576\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56549\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-150-db-iv-44934.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_44934/thumbs/54560_425489.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51658.json
+++ b/articles/piko/51658.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51658",
+  "manufacturer": "PIKO",
+  "articleNumber": "51658",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 329.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 150",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 224,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 150 DB IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51658\nEAN: 4015615516583\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-150-db-iv,-inkl.-piko-sound-decoder-44935.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44935/thumbs/54561_430494.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/51659.json
+++ b/articles/piko/51659.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-51659",
+  "manufacturer": "PIKO",
+  "articleNumber": "51659",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 329.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 150",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 224,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR 150 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 51659\nEAN: 4015615516590\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 224\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-150-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-44936.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44936/thumbs/54562_441331.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52105.json
+++ b/articles/piko/52105.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52105",
+  "manufacturer": "PIKO",
+  "articleNumber": "52105",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 215.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "T435 Industrie",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 144,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok T435 Industrie III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52105\nEAN: 4015615521051\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 144\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56583\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Beleuchtetes Nummernschild (nur digital schaltbar)\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-t435-industrie-iii-45033.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_45033/thumbs/56532_442143.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52105.json
+++ b/articles/piko/52105.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "CS",
     "operator": "Privatbahn",
     "type": "T435 Industrie",
     "number": null,

--- a/articles/piko/52106.json
+++ b/articles/piko/52106.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "CS",
     "operator": "Privatbahn",
     "type": "T435 Industrie",
     "number": null,

--- a/articles/piko/52106.json
+++ b/articles/piko/52106.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52106",
+  "manufacturer": "PIKO",
+  "articleNumber": "52106",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 325.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "T435 Industrie",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 144,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok T435 Industrie III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52106\nEAN: 4015615521068\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 144\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Beleuchtetes Nummernschild",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-t435-industrie-iii,-inkl.-piko-sound-decoder-45034.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45034/thumbs/56533_433989.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52115.json
+++ b/articles/piko/52115.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52115",
+  "manufacturer": "PIKO",
+  "articleNumber": "52115",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 239.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 248",
+    "number": null,
+    "livery": "IC",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Zweikraftlok \"dual mode\" BR 248 IC DB AG VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52115\nEAN: 4015615521150\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56631\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/zweikraftlok-dual-mode-br-248-ic-db-ag-vi-45776.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_z/oart_45776/thumbs/59412_524888.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52116.json
+++ b/articles/piko/52116.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52116",
+  "manufacturer": "PIKO",
+  "articleNumber": "52116",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 349.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 248",
+    "number": null,
+    "livery": "IC",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Zweikraftlok \"dual mode\" BR 248 IC DB AG VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52116\nEAN: 4015615521167\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-ic-db-ag-vi,-inkl.-piko-sound-decoder-45777.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45777/thumbs/59413_524894.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52117.json
+++ b/articles/piko/52117.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52117",
+  "manufacturer": "PIKO",
+  "articleNumber": "52117",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 349.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 248",
+    "number": null,
+    "livery": "IC",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 230,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Zweikraftlok \"dual mode\" BR 248 IC DB AG VI Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52117\nEAN: 4015615521174\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB AG\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 230\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Maschinenraumbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-zweikraftlok-dual-mode-br-248-ic-db-ag-vi-wechselstrom,-inkl.-piko-sound-decoder-45778.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45778/thumbs/59414_524903.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52308.json
+++ b/articles/piko/52308.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52308",
+  "manufacturer": "PIKO",
+  "articleNumber": "52308",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 195.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "Sm31",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 195,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok Sm31 PKP IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52308\nEAN: 4015615523086\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56607\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-sm31-pkp-iv-45214.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_45214/thumbs/56275_427967.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52309.json
+++ b/articles/piko/52309.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52309",
+  "manufacturer": "PIKO",
+  "articleNumber": "52309",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 305.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "Sm31",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 195,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok Sm31 PKP IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52309\nEAN: 4015615523093\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 195\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sm31-pkp-iv,-inkl.-piko-sound-decoder-45215.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45215/thumbs/56276_445428.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52364.json
+++ b/articles/piko/52364.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52364",
+  "manufacturer": "PIKO",
+  "articleNumber": "52364",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 249.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "IT",
+    "operator": "FS",
+    "type": "DE18 Mercitalia",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok DE18 Mercitalia VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52364\nEAN: 4015615523642\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56635\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-de18-mercitalia-vi-42685.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_42685/thumbs/56397_452090.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52365.json
+++ b/articles/piko/52365.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52365",
+  "manufacturer": "PIKO",
+  "articleNumber": "52365",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "IT",
+    "operator": "FS",
+    "type": "DE18 Mercitalia",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok DE18 Mercitalia VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52365\nEAN: 4015615523659\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-mercitalia-vi,-inkl.-piko-sound-decoder-42686.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_42686/thumbs/56398_454208.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52366.json
+++ b/articles/piko/52366.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52366",
+  "manufacturer": "PIKO",
+  "articleNumber": "52366",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "IT",
+    "operator": "FS",
+    "type": "DE18 Mercitalia",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 139,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok DE18 Mercitalia VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52366\nEAN: 4015615523666\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: FS\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 139\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-mercitalia-vi-wechselstromversion,-inkl.-piko-sound-decoder-42687.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_42687/thumbs/56399_423415.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52367.json
+++ b/articles/piko/52367.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "LU",
     "operator": "CFL",
     "type": "DE18 CFL",
     "number": null,

--- a/articles/piko/52367.json
+++ b/articles/piko/52367.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52367",
+  "manufacturer": "PIKO",
+  "articleNumber": "52367",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 249.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "CFL",
+    "type": "DE18 CFL",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok DE18 CFL VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52367\nEAN: 4015615523673\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CFL\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56635\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-de18-cfl-vi-45168.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_45168/thumbs/57999_508675.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52368.json
+++ b/articles/piko/52368.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "LU",
     "operator": "CFL",
     "type": "DE18 CFL",
     "number": null,

--- a/articles/piko/52368.json
+++ b/articles/piko/52368.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52368",
+  "manufacturer": "PIKO",
+  "articleNumber": "52368",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "CFL",
+    "type": "DE18 CFL",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok DE18 CFL VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52368\nEAN: 4015615523680\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CFL\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-cfl-vi,-inkl.-piko-sound-decoder-45169.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45169/thumbs/58000_508691.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52369.json
+++ b/articles/piko/52369.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "LU",
     "operator": "CFL",
     "type": "DE18 CFL",
     "number": null,

--- a/articles/piko/52369.json
+++ b/articles/piko/52369.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52369",
+  "manufacturer": "PIKO",
+  "articleNumber": "52369",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "CFL",
+    "type": "DE18 CFL",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok DE18 CFL VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52369\nEAN: 4015615523697\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CFL\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-cfl-vi-wechselstromversion,-inkl.-piko-sound-decoder-45170.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45170/thumbs/58001_508703.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52370.json
+++ b/articles/piko/52370.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52370",
+  "manufacturer": "PIKO",
+  "articleNumber": "52370",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 249.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "FR",
+    "operator": "SNCF",
+    "type": "DE18",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok DE18 SNCF VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52370\nEAN: 4015615523703\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: SNCF\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56635\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-de18-sncf-vi-45171.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_45171/thumbs/57619_502340.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52371.json
+++ b/articles/piko/52371.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52371",
+  "manufacturer": "PIKO",
+  "articleNumber": "52371",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "FR",
+    "operator": "SNCF",
+    "type": "DE18",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok DE18 SNCF VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52371\nEAN: 4015615523710\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: SNCF\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-sncf-vi,-inkl.-piko-sound-decoder-45172.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45172/thumbs/57620_502350.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52372.json
+++ b/articles/piko/52372.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52372",
+  "manufacturer": "PIKO",
+  "articleNumber": "52372",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "FR",
+    "operator": "SNCF",
+    "type": "DE18",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 196,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok DE18 SNCF VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52372\nEAN: 4015615523727\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: SNCF\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 196\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-de18-sncf-vi-wechselstromversion,-inkl.-piko-sound-decoder-45173.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45173/thumbs/57621_502524.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52507.json
+++ b/articles/piko/52507.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52507",
+  "manufacturer": "PIKO",
+  "articleNumber": "52507",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 245.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "HU",
+    "operator": "MAV",
+    "type": "NoHAB",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok NoHAB MAV IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52507\nEAN: 4015615525073\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56608\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-nohab-mav-iv-44937.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44937/thumbs/54916_409438.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52508.json
+++ b/articles/piko/52508.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52508",
+  "manufacturer": "PIKO",
+  "articleNumber": "52508",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 355.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "HU",
+    "operator": "MAV",
+    "type": "NoHAB",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok NoHAB MAV IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52508\nEAN: 4015615525080\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: MAV\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-nohab-mav-iv,-inkl.-piko-sound-decoder-44938.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44938/thumbs/54917_409025.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52509.json
+++ b/articles/piko/52509.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52509",
+  "manufacturer": "PIKO",
+  "articleNumber": "52509",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 355.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "HU",
+    "operator": "MAV",
+    "type": "NoHAB",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok NoHAB MAV IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52509\nEAN: 4015615525097\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: MAV\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-nohab-mav-iv-wechselstromversion,-inkl.-piko-sound-decoder-44939.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44939/thumbs/54918_406646.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52554.json
+++ b/articles/piko/52554.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52554",
+  "manufacturer": "PIKO",
+  "articleNumber": "52554",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 164.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "Privatbahn",
+    "type": "V 23 Captrain",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 80,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok V 23 Captrain VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52554\nEAN: 4015615525547\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 80\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56551\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-v-23-captrain-vi-44917.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44917/thumbs/56095_413529.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52567.json
+++ b/articles/piko/52567.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52567",
+  "manufacturer": "PIKO",
+  "articleNumber": "52567",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 199.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 216",
+    "number": null,
+    "livery": "DB Cargo",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 184,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok BR 216 DB Cargo V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52567\nEAN: 4015615525677\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 184\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56597\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-br-216-db-cargo-v-44919.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44919/thumbs/54772_439432.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52568.json
+++ b/articles/piko/52568.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52568",
+  "manufacturer": "PIKO",
+  "articleNumber": "52568",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 309.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 216",
+    "number": null,
+    "livery": "DB Cargo",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 184,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok BR 216 DB Cargo V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52568\nEAN: 4015615525684\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: DB AG\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 184\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-216-db-cargo-v,-inkl.-piko-sound-decoder-44920.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44920/thumbs/54773_442086.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52569.json
+++ b/articles/piko/52569.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52569",
+  "manufacturer": "PIKO",
+  "articleNumber": "52569",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 309.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "DE",
+    "operator": "DB",
+    "type": "BR 216",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 184,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok BR 216 DB IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52569\nEAN: 4015615525691\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: DB\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 184\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-br-216-db-iv-wechselstromversion,-inkl.-piko-sound-decoder-44921.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44921/thumbs/54774_449846.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52637.json
+++ b/articles/piko/52637.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 312",
     "number": null,

--- a/articles/piko/52637.json
+++ b/articles/piko/52637.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52637",
+  "manufacturer": "PIKO",
+  "articleNumber": "52637",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 174.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 312",
+    "number": null,
+    "livery": "EBS",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 92,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok BR 312 EBS VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52637\nEAN: 4015615526377\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 92\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56562\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Ausziehbare Antenne\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-br-312-ebs-vi-44980.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44980/thumbs/54520_425510.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52976.json
+++ b/articles/piko/52976.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52976",
+  "manufacturer": "PIKO",
+  "articleNumber": "52976",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 332.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "\"Desiro\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 479,
+    "minRadiusMm": 358
+  },
+  "description": "Dieseltriebwagen \"Desiro\" CD VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52976\nEAN: 4015615529767\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56581\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/dieseltriebwagen-desiro-cd-vi-44409.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44409/thumbs/54464_410908.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52977.json
+++ b/articles/piko/52977.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52977",
+  "manufacturer": "PIKO",
+  "articleNumber": "52977",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 441.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "\"Desiro\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 479,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Dieseltriebwagen \"Desiro\" CD VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52977\nEAN: 4015615529774\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dieseltriebwagen-desiro-cd-vi,-inkl.-piko-sound-decoder-44410.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44410/thumbs/54465_422007.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52978.json
+++ b/articles/piko/52978.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52978",
+  "manufacturer": "PIKO",
+  "articleNumber": "52978",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 441.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "\"Desiro\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 479,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Dieseltriebwagen \"Desiro\" CD VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52978\nEAN: 4015615529781\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dieseltriebwagen-desiro-cd-vi-wechselstromversion,-inkl.-piko-sound-decoder-44411.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44411/thumbs/54466_444385.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52982.json
+++ b/articles/piko/52982.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52982",
+  "manufacturer": "PIKO",
+  "articleNumber": "52982",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 332.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "Desiro",
+    "number": null,
+    "livery": "Midtjyske Jernbaner",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 479,
+    "minRadiusMm": 358
+  },
+  "description": "Dieseltriebwagen \"Desiro\" Midtjyske Jernbaner VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52982\nEAN: 4015615529828\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56581\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/dieseltriebwagen-desiro-midtjyske-jernbaner-vi-44858.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44858/thumbs/54467_448464.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52982.json
+++ b/articles/piko/52982.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DK",
     "operator": "Privatbahn",
     "type": "Desiro",
     "number": null,

--- a/articles/piko/52983.json
+++ b/articles/piko/52983.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DK",
     "operator": "Privatbahn",
     "type": "Desiro",
     "number": null,

--- a/articles/piko/52983.json
+++ b/articles/piko/52983.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52983",
+  "manufacturer": "PIKO",
+  "articleNumber": "52983",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 441.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "Desiro",
+    "number": null,
+    "livery": "Midtjyske Jernbaner",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 479,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Dieseltriebwagen \"Desiro\" Midtjyske Jernbaner VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52983\nEAN: 4015615529835\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dieseltriebwagen-desiro-midtjyske-jernbaner-vi,-inkl.-piko-sound-decoder-44859.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44859/thumbs/54468_441089.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52984.json
+++ b/articles/piko/52984.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DK",
     "operator": "Privatbahn",
     "type": "Desiro",
     "number": null,

--- a/articles/piko/52984.json
+++ b/articles/piko/52984.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52984",
+  "manufacturer": "PIKO",
+  "articleNumber": "52984",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 441.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "Desiro",
+    "number": null,
+    "livery": "Midtjyske Jernbaner",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 479,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Dieseltriebwagen \"Desiro\" Midtjyske Jernbaner VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52984\nEAN: 4015615529842\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 479\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Schaltbare Innenbeleuchtung werkseitig ausgerüstet\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-dieseltriebwagen-desiro-midtjyske-jernbaner-vi-wechselstromversion,-inkl.-piko-sound-decoder-44860.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44860/thumbs/54469_443947.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52985.json
+++ b/articles/piko/52985.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52985",
+  "manufacturer": "PIKO",
+  "articleNumber": "52985",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 179.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "V 60 D-2 WTK",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 652",
+    "era": "IV",
+    "luepMm": 125,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok V 60 D-2 WTK IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52985\nEAN: 4015615529859\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 125\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56618\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-v-60-d-2-wtk-iv-44675.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44675/thumbs/53947_421627.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52985.json
+++ b/articles/piko/52985.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "V 60 D-2 WTK",
     "number": null,

--- a/articles/piko/52986.json
+++ b/articles/piko/52986.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52986",
+  "manufacturer": "PIKO",
+  "articleNumber": "52986",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 289.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "V 60 D-2 WTK",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "IV",
+    "luepMm": 125,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok V 60 D-2 WTK IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52986\nEAN: 4015615529866\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 125\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-v-60-d-2-wtk-iv,-inkl.-piko-sound-decoder-44678.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44678/thumbs/53948_418414.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52986.json
+++ b/articles/piko/52986.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "V 60 D-2 WTK",
     "number": null,

--- a/articles/piko/52987.json
+++ b/articles/piko/52987.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "V 60 D-2 WTK",
     "number": null,

--- a/articles/piko/52987.json
+++ b/articles/piko/52987.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52987",
+  "manufacturer": "PIKO",
+  "articleNumber": "52987",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 289.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "V 60 D-2 WTK",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "IV",
+    "luepMm": 125,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok V 60 D-2 WTK IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52987\nEAN: 4015615529873\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 125\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-v-60-d-2-wtk-iv-wechselstromversion,-inkl.-piko-sound-decoder-44679.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44679/thumbs/53949_446998.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52989.json
+++ b/articles/piko/52989.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52989",
+  "manufacturer": "PIKO",
+  "articleNumber": "52989",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 209.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "NL",
+    "operator": "NS",
+    "type": "Rh",
+    "number": "2200",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 150,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok Rh 2200 NS IV Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52989\nEAN: 4015615529897\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 150\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56596\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-rh-2200-ns-iv-45165.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_45165/thumbs/56450_441272.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52990.json
+++ b/articles/piko/52990.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52990",
+  "manufacturer": "PIKO",
+  "articleNumber": "52990",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 319.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "NL",
+    "operator": "NS",
+    "type": "Rh",
+    "number": "2200",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 150,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok Rh 2200 NS IV, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52990\nEAN: 4015615529903\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 150\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rh-2200-ns-iv,-inkl.-piko-sound-decoder-45166.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45166/thumbs/56451_440291.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/52991.json
+++ b/articles/piko/52991.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-52991",
+  "manufacturer": "PIKO",
+  "articleNumber": "52991",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 319.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "NL",
+    "operator": "NS",
+    "type": "Rh",
+    "number": "2200",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "IV",
+    "luepMm": 150,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok Rh 2200 NS IV Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 52991\nEAN: 4015615529910\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: NS\nEpoche: IV\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 150\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-rh-2200-ns-iv-wechselstromversion,-inkl.-piko-sound-decoder-45167.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45167/thumbs/56452_448451.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/57365.json
+++ b/articles/piko/57365.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-57365",
+  "manufacturer": "PIKO",
+  "articleNumber": "57365",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 293.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "BR 55",
+    "number": null,
+    "livery": "(G7.1)",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 193,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Schlepptenderlok BR 55 (G7.1) ÖBB III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57365\nEAN: 4015615573654\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-br-55-g7.1-oebb-iii-wechselstromversion,-inkl.-piko-sound-decoder-44914.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44914/thumbs/54563_446144.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/57565.json
+++ b/articles/piko/57565.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-57565",
+  "manufacturer": "PIKO",
+  "articleNumber": "57565",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 179.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "BR 55",
+    "number": null,
+    "livery": "(G7.1)",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 193,
+    "minRadiusMm": 358
+  },
+  "description": "Schlepptenderlok BR 55 (G7.1) ÖBB III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57565\nEAN: 4015615575658\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder nachrüstbar #56629\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/schlepptenderlok-br-55-g7.1-oebb-iii-44912.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44912/thumbs/54564_441351.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/57566.json
+++ b/articles/piko/57566.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-57566",
+  "manufacturer": "PIKO",
+  "articleNumber": "57566",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 293.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "AT",
+    "operator": "ÖBB",
+    "type": "BR 55",
+    "number": null,
+    "livery": "(G7.1)",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 193,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Schlepptenderlok BR 55 (G7.1) ÖBB III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 57566\nEAN: 4015615575665\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: ÖBB\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 4\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / weiß\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-schlepptenderlok-br-55-g7.1-oebb-iii,-inkl.-piko-sound-decoder-44913.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44913/thumbs/54565_432010.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/59276.json
+++ b/articles/piko/59276.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-59276",
+  "manufacturer": "PIKO",
+  "articleNumber": "59276",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 179.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "Privatbahn",
+    "type": "SM42",
+    "number": null,
+    "livery": "CargoUnit",
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 164,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok SM42 CargoUnit VI Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59276\nEAN: 4015615592761\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 164\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht / keine Kurzkupplungskulisse\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-sm42-cargounit-vi-44918.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44918/thumbs/56100_436322.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/59317.json
+++ b/articles/piko/59317.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-59317",
+  "manufacturer": "PIKO",
+  "articleNumber": "59317",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 379.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 442",
+    "number": null,
+    "livery": "Talent 2",
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 636,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Triebwagen BR 442 \"Talent 2\" National Express VI 3tlg Wechselstrom, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59317\nEAN: 4015615593171\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 636\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Werkseitig nicht für Innenbeleuchtung vorbereitet\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-triebwagen-br-442-talent-2-national-express-vi-3tlg-wechselstrom,-inkl.-piko-sound-decoder-45461.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45461/thumbs/56670_471436.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/59317.json
+++ b/articles/piko/59317.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 442",
     "number": null,

--- a/articles/piko/59517.json
+++ b/articles/piko/59517.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 442",
     "number": null,

--- a/articles/piko/59517.json
+++ b/articles/piko/59517.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-59517",
+  "manufacturer": "PIKO",
+  "articleNumber": "59517",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 269.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 442",
+    "number": null,
+    "livery": "Talent 2",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 636,
+    "minRadiusMm": 358
+  },
+  "description": "E-Triebwagen BR 442 \"Talent 2\" National Express VI 3tlg Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59517\nEAN: 4015615595175\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 636\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-polig\n(Innen-)Beleuchtung: Werkseitig nicht für Innenbeleuchtung vorbereitet\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56614\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-triebwagen-br-442-talent-2-national-express-vi-3tlg-45459.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45459/thumbs/56671_471244.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/59518.json
+++ b/articles/piko/59518.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-59518",
+  "manufacturer": "PIKO",
+  "articleNumber": "59518",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 379.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": "Privatbahn",
+    "type": "BR 442",
+    "number": null,
+    "livery": "Talent 2",
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 652",
+    "era": "VI",
+    "luepMm": 636,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Triebwagen BR 442 \"Talent 2\" National Express VI 3tlg, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 59518\nEAN: 4015615595182\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: Privatbahn\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 636\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 652\nVerbauter Decoder: 8-poliger Sounddecoder\n(Innen-)Beleuchtung: Werkseitig nicht für Innenbeleuchtung vorbereitet\nAnzahl Haftreifen: 4\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Spezialkupplung für Mehrfachtraktion liegt bei",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-triebwagen-br-442-talent-2-national-express-vi-3tlg,-inkl.-piko-sound-decoder-45460.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45460/thumbs/56672_471912.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/59518.json
+++ b/articles/piko/59518.json
@@ -9,7 +9,7 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
+    "country": "DE",
     "operator": "Privatbahn",
     "type": "BR 442",
     "number": null,

--- a/articles/piko/96397.json
+++ b/articles/piko/96397.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-96397",
+  "manufacturer": "PIKO",
+  "articleNumber": "96397",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 219.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "EU07",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 183,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok EU07 PKP V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96397\nEAN: 4015615963974\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56552\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Oberleitungsbetrieb möglich\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-eu07-pkp-v-45337.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45337/thumbs/56686_471487.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/96398.json
+++ b/articles/piko/96398.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-96398",
+  "manufacturer": "PIKO",
+  "articleNumber": "96398",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 329.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "EU07",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 183,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok EU07 PKP V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 96398\nEAN: 4015615963981\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 183\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Oberleitungsbetrieb möglich",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-eu07-pkp-v,-inkl.-piko-sound-decoder-45338.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45338/thumbs/56687_471541.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/96493.json
+++ b/articles/piko/96493.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "FR",
     "operator": "SNCF",
-    "type": "BB 60000",
-    "number": null,
+    "type": "BB",
+    "number": "60000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/96494.json
+++ b/articles/piko/96494.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "FR",
     "operator": "SNCF",
-    "type": "BB 60000",
-    "number": null,
+    "type": "BB",
+    "number": "60000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/97411.json
+++ b/articles/piko/97411.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97411",
+  "manufacturer": "PIKO",
+  "articleNumber": "97411",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 339.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "Rh",
+    "number": "242",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 189,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok Rh 242 CD VI, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97411\nEAN: 4015615974116\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-242-cd-vi,-inkl.-piko-sound-decoder-45016.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45016/thumbs/55885_435303.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97412.json
+++ b/articles/piko/97412.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97412",
+  "manufacturer": "PIKO",
+  "articleNumber": "97412",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 339.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "CZ",
+    "operator": "CD",
+    "type": "Rh",
+    "number": "242",
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "VI",
+    "luepMm": 189,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok Rh 242 CD VI Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97412\nEAN: 4015615974123\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nBahnverwaltung: CD\nEpoche: VI\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 189\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstands- und Maschinenraumbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-rh-242-cd-vi-wechselstromversion,-inkl.-piko-sound-decoder-45017.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45017/thumbs/55886_448780.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97504.json
+++ b/articles/piko/97504.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 1000",
-    "number": null,
+    "type": "Rh",
+    "number": "1000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/97505.json
+++ b/articles/piko/97505.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 1000",
-    "number": null,
+    "type": "Rh",
+    "number": "1000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/97506.json
+++ b/articles/piko/97506.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "NL",
     "operator": "NS",
-    "type": "Rh 1000",
-    "number": null,
+    "type": "Rh",
+    "number": "1000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",

--- a/articles/piko/97528.json
+++ b/articles/piko/97528.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97528",
+  "manufacturer": "PIKO",
+  "articleNumber": "97528",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 249.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "EP09",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 193,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok EP09 PKP V Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97528\nEAN: 4015615975281\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56636\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-ep09-pkp-v-45773.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_45773/thumbs/56153_424923.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97529.json
+++ b/articles/piko/97529.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97529",
+  "manufacturer": "PIKO",
+  "articleNumber": "97529",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 359.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "PL",
+    "operator": "PKP",
+    "type": "EP09",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "V",
+    "luepMm": 193,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok EP09 PKP V, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97529\nEAN: 4015615975298\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: PKP\nEpoche: V\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 193\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\n(Innen-)Beleuchtung: Digital schaltbare Führerstandsbeleuchtung (mit PluX22 Decoder)\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nBesonderheiten: Führerpultbeleuchtung\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-ep09-pkp-v,-inkl.-piko-sound-decoder-45775.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_45775/thumbs/56154_408579.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97540.json
+++ b/articles/piko/97540.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "FR",
     "operator": "SNCF",
-    "type": "CC 65000",
-    "number": null,
+    "type": "CC",
+    "number": "65000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Analog",

--- a/articles/piko/97542.json
+++ b/articles/piko/97542.json
@@ -11,8 +11,8 @@
   "model": {
     "country": "FR",
     "operator": "SNCF",
-    "type": "CC 65000",
-    "number": null,
+    "type": "CC",
+    "number": "65000",
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",

--- a/articles/piko/97803.json
+++ b/articles/piko/97803.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97803",
+  "manufacturer": "PIKO",
+  "articleNumber": "97803",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 269.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "IT",
+    "operator": "FS",
+    "type": "BR E.428 3. aerodynamische Serie",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Analog",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 222,
+    "minRadiusMm": 358
+  },
+  "description": "E-Lok BR E.428 3. aerodynamische Serie FS III Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97803\nEAN: 4015615978039\nHersteller: PIKO\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 222\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder nachrüstbar #56623\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/e-lok-br-e.428-3.-aerodynamische-serie-fs-iii-41338.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_e/oart_41338/thumbs/56539_445408.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97804.json
+++ b/articles/piko/97804.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97804",
+  "manufacturer": "PIKO",
+  "articleNumber": "97804",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 379.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "IT",
+    "operator": "FS",
+    "type": "BR E.428 3. aerodynamische Serie",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR E.428 3. aerodynamische Serie FS III, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97804\nEAN: 4015615978046\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nBahnverwaltung: FS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-e.428-3.-aerodynamische-serie-fs-iii,-inkl.-piko-sound-decoder-44759.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44759/thumbs/56540_434711.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97805.json
+++ b/articles/piko/97805.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97805",
+  "manufacturer": "PIKO",
+  "articleNumber": "97805",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 379.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": "IT",
+    "operator": "FS",
+    "type": "BR E.428 3. aerodynamische Serie",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": "III",
+    "luepMm": 218,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-E-Lok BR E.428 3. aerodynamische Serie FS III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97805\nEAN: 4015615978053\nHersteller: PIKO\nSound ja/nein: Ja\nStromsystem: Wechselstrom\nBahnverwaltung: FS\nEpoche: III\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 218\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nAnzahl Haftreifen: 2\nKupplung: NEM Schacht + Kurzkupplungskulisse\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-e-lok-br-e.428-3.-aerodynamische-serie-fs-iii-wechselstromversion,-inkl.-piko-sound-decoder-44761.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44761/thumbs/56541_411821.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97822.json
+++ b/articles/piko/97822.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9100 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97822.json
+++ b/articles/piko/97822.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97822",
+  "manufacturer": "PIKO",
+  "articleNumber": "97822",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 349.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9100 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok SP 9100 \"Modifiziert\" Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97822\nEAN: 4015615978220\nHersteller: PIKO\nStromsystem: Gleichstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nSound: PIKO Sound-Decoder nachrüstbar #56627\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-sp-9100-modifiziert-44702.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44702/thumbs/54521_447746.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97823.json
+++ b/articles/piko/97823.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9100 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97823.json
+++ b/articles/piko/97823.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97823",
+  "manufacturer": "PIKO",
+  "articleNumber": "97823",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9100 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok SP 9100 \"Modifiziert\", inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97823\nEAN: 4015615978237\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sp-9100-modifiziert-,-inkl.-piko-sound-decoder-44703.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44703/thumbs/54522_444648.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97824.json
+++ b/articles/piko/97824.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97824",
+  "manufacturer": "PIKO",
+  "articleNumber": "97824",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9100 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok SP 9100 \"Modifiziert\" Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97824\nEAN: 4015615978244\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sp-9100-modifiziert-wechselstromversion,-inkl.-piko-sound-decoder-44704.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44704/thumbs/54523_454457.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97824.json
+++ b/articles/piko/97824.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9100 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97825.json
+++ b/articles/piko/97825.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97825",
+  "manufacturer": "PIKO",
+  "articleNumber": "97825",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 349.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9101 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok SP 9101 \"Modifiziert\" Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97825\nEAN: 4015615978251\nHersteller: PIKO\nStromsystem: Gleichstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nSound: PIKO Sound-Decoder nachrüstbar #56627\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-sp-9101-modifiziert-44705.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44705/thumbs/54524_410588.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97825.json
+++ b/articles/piko/97825.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9101 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97826.json
+++ b/articles/piko/97826.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97826",
+  "manufacturer": "PIKO",
+  "articleNumber": "97826",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9101 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok SP 9101 \"Modifiziert\", inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97826\nEAN: 4015615978268\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sp-9101-modifiziert-,-inkl.-piko-sound-decoder-44706.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44706/thumbs/54525_447087.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97826.json
+++ b/articles/piko/97826.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9101 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97827.json
+++ b/articles/piko/97827.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9001 \"Ursprung\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97827.json
+++ b/articles/piko/97827.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97827",
+  "manufacturer": "PIKO",
+  "articleNumber": "97827",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9001 \"Ursprung\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok SP 9001 \"Ursprung\" III Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97827\nEAN: 4015615978275\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sp-9001-ursprung-iii-wechselstromversion,-inkl.-piko-sound-decoder-44707.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44707/thumbs/54526_454456.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97828.json
+++ b/articles/piko/97828.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97828",
+  "manufacturer": "PIKO",
+  "articleNumber": "97828",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 349.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9102 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Diesellok SP 9102 \"Modifiziert\" Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97828\nEAN: 4015615978282\nHersteller: PIKO\nStromsystem: Gleichstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22\nAnzahl Haftreifen: 2\nSound: PIKO Sound-Decoder nachrüstbar #56627\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/diesellok-sp-9102-modifiziert-44708.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_d/oart_44708/thumbs/54531_441340.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97828.json
+++ b/articles/piko/97828.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9102 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97829.json
+++ b/articles/piko/97829.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97829",
+  "manufacturer": "PIKO",
+  "articleNumber": "97829",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9102 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "DC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok SP 9102 \"Modifiziert\", inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97829\nEAN: 4015615978299\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Gleichstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sp-9102-modifiziert-,-inkl.-piko-sound-decoder-44709.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44709/thumbs/54532_447088.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97829.json
+++ b/articles/piko/97829.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9102 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "DC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/articles/piko/97830.json
+++ b/articles/piko/97830.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "piko-97830",
+  "manufacturer": "PIKO",
+  "articleNumber": "97830",
+  "releaseDate": null,
+  "uvp": {
+    "amount": 449.0,
+    "currency": "EUR"
+  },
+  "model": {
+    "country": null,
+    "operator": null,
+    "type": "SP 9102 \"Modifiziert\"",
+    "number": null,
+    "livery": null,
+    "scale": "H0",
+    "electricSystem": "AC-Digital",
+    "decoderInterface": "NEM 658 PluX22",
+    "era": null,
+    "luepMm": 231,
+    "minRadiusMm": 358
+  },
+  "description": "Sound-Diesellok SP 9102 \"Modifiziert\" Wechselstromversion, inkl. PIKO Sound-Decoder Modelleisenbahn kaufen | PIKO Webshop\n\nArtikelnummer: 97830\nEAN: 4015615978305\nHersteller: PIKO\nSound ja/nein: ja\nStromsystem: Wechselstrom\nMaßbezeichnung: LüP / Länge über Puffer\nMaß [mm]: 231\nMindestradius [mm]: 358\nDigitale Schnittstelle: NEM 658 PluX22\nVerbauter Decoder: PluX22 Sounddecoder\nSound: PIKO Sound-Decoder werkseitig ausgerüstet\nLichtwechsel: Fahrtrichtungsabhängiger Lichtwechsel weiß / rot\nAltersempfehlung: ab 14 Jahren",
+  "categories": [],
+  "tags": [
+    "piko-neuheiten-2025"
+  ],
+  "source": {
+    "url": "https://www.piko-shop.de/de/artikel/sound-diesellok-sp-9102-modifiziert-wechselstromversion,-inkl.-piko-sound-decoder-44710.html",
+    "notes": "Daten von der Webseite, automatisch geupdated.",
+    "imageUrl": "https://www.piko-shop.de/media/oart_0/oart_s/oart_44710/thumbs/54533_432693.jpg"
+  },
+  "updatedAt": "2026-05-18T04:38:22Z"
+}

--- a/articles/piko/97830.json
+++ b/articles/piko/97830.json
@@ -9,15 +9,15 @@
     "currency": "EUR"
   },
   "model": {
-    "country": null,
-    "operator": null,
+    "country": "US",
+    "operator": "Southern Pacific",
     "type": "SP 9102 \"Modifiziert\"",
     "number": null,
     "livery": null,
     "scale": "H0",
     "electricSystem": "AC-Digital",
     "decoderInterface": "NEM 658 PluX22",
-    "era": null,
+    "era": "III",
     "luepMm": 231,
     "minRadiusMm": 358
   },

--- a/config/tags/piko-neuheiten-2025.json
+++ b/config/tags/piko-neuheiten-2025.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": "1.0.0",
+  "name": "PIKO Neuheiten 2025",
+  "slug": "piko-neuheiten-2025",
+  "description": "Artikel aus dem PIKO-Neuheitenkatalog 2025."
+}

--- a/utils/agents/lok-numbering-article-review/scripts/autofix_model_country.py
+++ b/utils/agents/lok-numbering-article-review/scripts/autofix_model_country.py
@@ -151,6 +151,7 @@ _OPERATOR_COUNTRY: dict[str, str] = {
     "SNCB": "BE",
     "D&RGW": "US",
     "SP (Southern Pacific)": "US",
+    "CFL": "LU",
 }
 
 
@@ -191,13 +192,51 @@ def _privatbahn_infer_country(article: Article) -> Optional[tuple[str, str]]:
         ("privatbahn_de_beacon", "DE", lambda: "beacon" in c),
         ("privatbahn_de_clr", "DE", lambda: "cargo logistic rail" in c),
         ("privatbahn_de_wfl", "DE", lambda: " wfl" in c or "wfl vi" in c),
-        ("privatbahn_de_press", "DE", lambda: ("traxx" in c and "press" in c) or ("br 248" in c and "press" in c)),
+        ("privatbahn_de_press", "DE", lambda: ("traxx" in c and "press" in c) or ("br 248" in c and "press" in c) or ("br 140" in c and "press" in c)),
+        ("privatbahn_de_hsl", "DE", lambda: " hsl" in c or "hsl logistik" in c),
+        ("privatbahn_de_ebs", "DE", lambda: " ebs" in c or "br 312" in c),
+        ("privatbahn_de_national_express", "DE", lambda: "national express" in c),
+        ("privatbahn_de_wtk", "DE", lambda: "wtk" in c or "v 60 d-2" in c),
+        ("privatbahn_pl_wlc", "PL", lambda: " wlc" in c or "wlc vi" in c),
+        ("privatbahn_de_alpha_trains", "DE", lambda: "alpha trains" in c),
+        ("privatbahn_ch_bern", "CH", lambda: "s-bahn bern" in c or "bern rm" in c),
+        ("privatbahn_cs_t435", "CS", lambda: "t435" in c),
+        ("privatbahn_dk_midtjyske", "DK", lambda: "midtjyske" in c),
         ("privatbahn_de_railion", "DE", lambda: "railion" in c),
     ]
     for rule_id, iso, fn in checks:
         if fn():
             return (rule_id, iso)
     return None
+
+
+def _propose_sp_operator_era(article: Article) -> Optional[tuple[str, str, Optional[str]]]:
+    """SP KM ML 4000: fehlender Operator/Epoche nach Shop-Import (US, Ep. III)."""
+    model = article.get("model")
+    if not isinstance(model, dict):
+        return None
+    t = str(model.get("type") or "")
+    if not re.search(r"\bSP\s+9", t, re.I):
+        return None
+    blob = _text_blob(article)
+    op_out: Optional[str] = None
+    if model.get("operator") is None or (
+        isinstance(model.get("operator"), str) and not str(model.get("operator")).strip()
+    ):
+        op_out = "Southern Pacific"
+    era_out: Optional[str] = None
+    era = model.get("era")
+    if era is None or (isinstance(era, str) and not str(era).strip()):
+        em = re.search(r"Epoche:\s*([IVX]+(?:-[IVX]+)*)", blob, re.I)
+        if em:
+            era_out = em.group(1).strip()
+        elif re.search(r"\bIII\b", blob):
+            era_out = "III"
+        else:
+            era_out = "III"
+    if op_out is None and era_out is None:
+        return None
+    return ("sp_km_ml", op_out, era_out)
 
 
 def propose_country(article: Article) -> Optional[tuple[str, str]]:
@@ -207,6 +246,10 @@ def propose_country(article: Article) -> Optional[tuple[str, str]]:
     model = article.get("model")
     if not isinstance(model, dict) or not _country_missing(model):
         return None
+
+    sp = _propose_sp_operator_era(article)
+    if sp and _country_missing(model):
+        return ("sp_km_ml", "US")
 
     op = _norm_op(model.get("operator"))
     if not op:
@@ -263,15 +306,39 @@ def main(argv: list[str]) -> int:
         if not isinstance(model, dict):
             continue
         prop = propose_country(data)
-        if not prop:
+        sp_fields = _propose_sp_operator_era(data)
+        if not prop and not sp_fields:
             continue
-        rule_id, new_c = prop
-        old_c = model.get("country")
-        if old_c == new_c:
-            continue
-        changed.append((path, rule_id, new_c))
-        if not dry_run:
-            model["country"] = new_c
+        file_dirty = False
+        if prop:
+            rule_id, new_c = prop
+            old_c = model.get("country")
+            if old_c != new_c:
+                changed.append((path, rule_id, new_c))
+                if not dry_run:
+                    model["country"] = new_c
+                    file_dirty = True
+        if sp_fields:
+            _, new_op, new_era = sp_fields
+            if new_op and (
+                model.get("operator") is None
+                or (isinstance(model.get("operator"), str) and not model.get("operator").strip())
+            ):
+                if not dry_run:
+                    model["operator"] = new_op
+                    file_dirty = True
+                else:
+                    print(f"{path}\tsp_km_ml\toperator -> {new_op!r}", file=sys.stderr)
+            if new_era and (
+                model.get("era") is None
+                or (isinstance(model.get("era"), str) and not str(model.get("era")).strip())
+            ):
+                if not dry_run:
+                    model["era"] = new_era
+                    file_dirty = True
+                else:
+                    print(f"{path}\tsp_km_ml\tera -> {new_era!r}", file=sys.stderr)
+        if file_dirty:
             save_article(path, data)
 
     for path, rule_id, new_c in changed:

--- a/utils/agents/lok-numbering-article-review/scripts/autofix_piko_shop_type.py
+++ b/utils/agents/lok-numbering-article-review/scripts/autofix_piko_shop_type.py
@@ -40,9 +40,9 @@ def _strip_prefix(t: str) -> str:
         old = u
         u = re.sub(r"^Sound[- ]?", "", u, count=1, flags=re.I)
         u = re.sub(
-            r"^(Zweikraftlok|Elektrotriebwagen|Dieseltriebwagen|Elektrolokomotive|"
-            r"Diesellokomotive|Schlepptenderlok|Dampflok|Elektrolok|Diesellok|"
-            r"E[- ]?Triebzug|E-Triebzug|Sound-E-Triebzug|E-Lok|Zugset)\s+",
+            r"^(Zweikraftlok|Elektrotriebwagen|Elektrotriebzug|Dieseltriebwagen|"
+            r"Elektrolokomotive|Diesellokomotive|Schlepptenderlok|Dampflok|Elektrolok|"
+            r"Diesellok|E[- ]?Triebzug|E-Triebzug|Sound-E-Triebzug|E-Lok|Zugset)\s+",
             "",
             u,
             count=1,
@@ -90,6 +90,34 @@ def _livery_ok(current: Any) -> bool:
     return current is None or (isinstance(current, str) and not current.strip())
 
 
+def _propose_livery_cleanup(liv: str) -> Optional[str]:
+    """Import-Artefakte: Epoche/Stromsystem/Setlänge aus ``livery`` entfernen."""
+    s = liv.strip()
+    if not s or len(s) > 80:
+        return None
+    tail = re.match(r"^([A-Za-z][A-Za-z0-9-]+)\s+(?:DB|VI)\b", s, re.I)
+    if tail and not re.search(r"cargo|express", s, re.I):
+        name = tail.group(1).strip()
+        return name if name and len(name) <= 48 else None
+    if not re.search(r"\d-tlg|wechselstrom|db ag\s+vi|national express", s, re.I):
+        return None
+    q = re.match(r'^["\u201e\u201c]([^"\u201d\u201c]+)["\u201d\u201c]', s)
+    if q:
+        name = q.group(1).strip()
+        return name if name and len(name) <= 48 else None
+    m = re.match(r"^([A-Za-z][A-Za-z0-9]*(?:\s+[A-Za-z][A-Za-z0-9]*)?)", s)
+    if not m:
+        return None
+    name = m.group(1).strip()
+    if re.search(r"\d-tlg|db ag", s, re.I):
+        name = re.split(r"\s+(?:DB|DR|PKP|AG|VI)\b", name, maxsplit=1, flags=re.I)[0].strip()
+    if name.lower() in ("db", "pkp", "obb", "sbb", "dr", "fs"):
+        return None
+    if name.lower().startswith("cd "):
+        return name if len(name) <= 48 else None
+    return name if len(name) <= 48 else None
+
+
 def _pick_livery(article: Article, candidate: Optional[str]) -> Optional[str]:
     if not candidate or not _livery_ok((article.get("model") or {}).get("livery")):
         return None
@@ -98,9 +126,6 @@ def _pick_livery(article: Article, candidate: Optional[str]) -> Optional[str]:
         return None
     if len(c) > 48:
         return None
-    return c
-
-
     return c
 
 
@@ -132,6 +157,11 @@ def _propose_refined_split(clean: str, article: Article) -> Optional[Fix]:
 
     if re.fullmatch(r"Taurus CityJet", clean, re.I):
         return ("piko_taurus", "1216", None, _pick_livery(article, "CityJet"), None)
+
+    m = re.match(r'^GTW\s+2/6(?:\s+"([^"]+)")?(?:\s+(.+))?$', clean, re.I)
+    if m:
+        liv = _pick_livery(article, m.group(1) or (m.group(2) or "").strip() or None)
+        return ("piko_gtw", "GTW 2/6", None, liv, None)
 
     m = re.fullmatch(r"S-200\s+(.+)", clean, re.I)
     if m:
@@ -236,6 +266,12 @@ def propose_fix(article: Article) -> Optional[Fix]:
     if clean != raw.strip():
         return ("piko_clean", clean, None, None, None)
 
+    cur_liv = (model.get("livery") or "")
+    if isinstance(cur_liv, str) and cur_liv.strip():
+        new_liv = _propose_livery_cleanup(cur_liv)
+        if new_liv and new_liv != cur_liv.strip():
+            return ("piko_livery", model.get("type"), None, new_liv, None)
+
     return None
 
 
@@ -271,7 +307,10 @@ def main(argv: list[str]) -> int:
         model = data["model"]
         old_t, old_n, old_liv = model.get("type"), model.get("number"), model.get("livery")
         old_op = model.get("operator")
-        if (
+        if rule == "piko_livery":
+            if old_liv == new_liv:
+                continue
+        elif (
             old_t == new_t
             and old_n == new_n
             and (new_liv is None or old_liv == new_liv)
@@ -283,9 +322,10 @@ def main(argv: list[str]) -> int:
         op = "" if new_op is None else f" operator={new_op!r}"
         print(f"{path}\t{rule}\t{old_t!r}/{old_n!r} -> {new_t!r}/{nn}{liv}{op}")
         if not dry:
-            model["type"] = new_t
-            model["number"] = new_n if new_n else None
-            if new_liv and _livery_ok(old_liv):
+            if rule != "piko_livery":
+                model["type"] = new_t
+                model["number"] = new_n if new_n else None
+            if new_liv and (rule == "piko_livery" or _livery_ok(old_liv)):
                 model["livery"] = new_liv
             if new_op:
                 model["operator"] = new_op

--- a/utils/piko/shop-pdp-parse/piko_mcp_chrome_search_import.py
+++ b/utils/piko/shop-pdp-parse/piko_mcp_chrome_search_import.py
@@ -431,6 +431,8 @@ async def _run_piko_mcp_import(
     notes: str,
     dry_run: bool,
     use_network_image: bool,
+    campaign_tag: Optional[str],
+    replace_tags: Optional[list[str]],
 ) -> tuple[int, int]:
     if sys.version_info < (3, 10):
         print("error: Python 3.10+ nötig (Paket mcp).", file=sys.stderr)
@@ -608,6 +610,12 @@ async def _run_piko_mcp_import(
                     ]
                     if image_url_override:
                         pargs.extend(["--image-url", image_url_override])
+                    ct = (campaign_tag or "").strip()
+                    if write and ct:
+                        pargs.extend(["--campaign-tag", ct])
+                    for rt in replace_tags or []:
+                        if rt.strip():
+                            pargs.extend(["--replace-tag", rt.strip()])
                     if write:
                         pargs.extend(["--write", "--quiet"])
                     proc = subprocess.run(pargs, cwd=str(_REPO_ROOT), timeout=300)
@@ -696,7 +704,32 @@ def main() -> int:
         action="store_true",
         help="Kein list_network_requests; og:image weiter per DOM.",
     )
+    ap.add_argument(
+        "--campaign-tag",
+        default=None,
+        metavar="SLUG",
+        help="Mit --write: Parser bekommt --campaign-tag (z. B. piko-neuheiten-2025).",
+    )
+    ap.add_argument(
+        "--replace-tag",
+        action="append",
+        metavar="SLUG",
+        default=None,
+        help="Mit --write: Parser --replace-tag (z. B. piko-neuheiten-2026). Mehrfach möglich.",
+    )
     args = ap.parse_args()
+    if args.campaign_tag and (args.no_write or args.dry_run):
+        print(
+            "error: --campaign-tag nur mit echtem --write (ohne --dry-run, ohne --no-write).",
+            file=sys.stderr,
+        )
+        return 2
+    if args.replace_tag and (args.no_write or args.dry_run):
+        print(
+            "error: --replace-tag nur mit echtem --write (ohne --dry-run, ohne --no-write).",
+            file=sys.stderr,
+        )
+        return 2
 
     mcp_extra_env: Optional[dict[str, str]] = None
     if args.mcp_from_cursor:
@@ -732,6 +765,8 @@ def main() -> int:
             notes=args.notes,
             dry_run=args.dry_run,
             use_network_image=not args.no_network_image,
+            campaign_tag=args.campaign_tag,
+            replace_tags=args.replace_tag,
         )
     )
     return 1 if fail else 0

--- a/utils/piko/shop-pdp-parse/piko_shop_parse_pdp.py
+++ b/utils/piko/shop-pdp-parse/piko_shop_parse_pdp.py
@@ -430,6 +430,29 @@ def parse_html(
     return payload
 
 
+def _finalize_tags(
+    existing_tags: list[Any],
+    *,
+    campaign_tag: Optional[str],
+    replace_tags: Optional[list[str]],
+) -> list[str]:
+    """Kampagnen-Tag setzen; ``replace_tags`` durch ``campaign_tag`` ersetzen (Reihenfolge behalten)."""
+    tags: list[str] = [t for t in existing_tags if isinstance(t, str) and t.strip()]
+    ct = (campaign_tag or "").strip()
+    replace = {t.strip() for t in (replace_tags or []) if isinstance(t, str) and t.strip()}
+    if ct and replace:
+        tags = [ct if t in replace else t for t in tags]
+    if ct and ct not in tags:
+        tags.append(ct)
+    seen: set[str] = set()
+    out: list[str] = []
+    for t in tags:
+        if t not in seen:
+            seen.add(t)
+            out.append(t)
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="PIKO Shop PDP-HTML → articles/piko JSON.")
     src = ap.add_mutually_exclusive_group(required=True)
@@ -440,8 +463,30 @@ def main() -> int:
     ap.add_argument("--notes", default="Daten von der Webseite, automatisch geupdated.")
     ap.add_argument("--image-url", default=None, help="Bild-URL überschreiben (z. B. aus Netzwerk).")
     ap.add_argument("--write", action="store_true", help="Nach articles/piko/{nr}.json schreiben.")
+    ap.add_argument(
+        "--campaign-tag",
+        metavar="SLUG",
+        default=None,
+        help="Nur mit --write: Slug zu tags hinzufügen (z. B. piko-neuheiten-2025).",
+    )
+    ap.add_argument(
+        "--replace-tag",
+        action="append",
+        metavar="SLUG",
+        default=None,
+        help=(
+            "Nur mit --write: vor --campaign-tag diese Slugs ersetzen "
+            "(mehrfach oder kommagetrennt; z. B. piko-neuheiten-2026)."
+        ),
+    )
     ap.add_argument("--quiet", action="store_true", help="Weniger stdout bei --write.")
     args = ap.parse_args()
+    if args.campaign_tag and not args.write:
+        print("error: --campaign-tag nur mit --write.", file=sys.stderr)
+        return 2
+    if args.replace_tag and not args.write:
+        print("error: --replace-tag nur mit --write.", file=sys.stderr)
+        return 2
 
     if args.stdin:
         html = sys.stdin.read()
@@ -461,10 +506,29 @@ def main() -> int:
     if args.notes:
         data["source"]["notes"] = str(args.notes)
 
+    replace_tags: list[str] = []
+    for chunk in args.replace_tag or []:
+        replace_tags.extend(p.strip() for p in chunk.split(",") if p.strip())
+
     if args.write:
         out_dir = _DEFAULT_ARTICLES
         out_dir.mkdir(parents=True, exist_ok=True)
         out_path = out_dir / f"{args.article}.json"
+        existing_tags: list[Any] = []
+        if out_path.is_file():
+            try:
+                prev = json.loads(out_path.read_text(encoding="utf-8"))
+                existing_tags = prev.get("tags") or []
+            except (json.JSONDecodeError, OSError):
+                existing_tags = []
+        if args.campaign_tag or replace_tags:
+            data["tags"] = _finalize_tags(
+                existing_tags,
+                campaign_tag=args.campaign_tag,
+                replace_tags=replace_tags or None,
+            )
+        elif existing_tags:
+            data["tags"] = list(existing_tags)
         out_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         if not args.quiet:
             print(str(out_path))

--- a/utils/piko/shop-pdp-parse/test_piko_shop_parse_pdp.py
+++ b/utils/piko/shop-pdp-parse/test_piko_shop_parse_pdp.py
@@ -53,5 +53,23 @@ class TestPikoElectricSystem(unittest.TestCase):
         self.assertEqual(m._canonical_electric_system_from_description(desc), "AC-Digital")
 
 
+class TestPikoCampaignTags(unittest.TestCase):
+    def test_replace_2026_with_2025(self) -> None:
+        out = m._finalize_tags(
+            ["piko-neuheiten-2026", "other"],
+            campaign_tag="piko-neuheiten-2025",
+            replace_tags=["piko-neuheiten-2026"],
+        )
+        self.assertEqual(out, ["piko-neuheiten-2025", "other"])
+
+    def test_add_campaign_on_empty(self) -> None:
+        out = m._finalize_tags(
+            [],
+            campaign_tag="piko-neuheiten-2025",
+            replace_tags=["piko-neuheiten-2026"],
+        )
+        self.assertEqual(out, ["piko-neuheiten-2025"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/utils/shop-import/README.md
+++ b/utils/shop-import/README.md
@@ -48,8 +48,10 @@ python3 utils/piko/catalog-extract/extract_piko_h0_catalog.py \
 **Nur Shop (beliebige Teilmenge, Delay wichtig):**
 
 ```bash
-python3 utils/piko/shop-pdp-parse/piko_mcp_chrome_search_import.py \
+.venv/bin/python utils/piko/shop-pdp-parse/piko_mcp_chrome_search_import.py \
   --articles .tmp/nur_diese_nummern.txt \
   --mcp-from-cursor \
+  --campaign-tag piko-neuheiten-2025 \
+  --replace-tag piko-neuheiten-2026 \
   --delay 3.0
 ```


### PR DESCRIPTION
## Summary

- Import von 121 PIKO H0 Neuheiten 2025 (Loks, Triebzüge, Triebwagen) aus dem Shop per Chrome-DevTools-MCP und `piko_shop_parse_pdp.py`.
- Neuer Tag `piko-neuheiten-2025`; MCP/Parser unterstützen `--campaign-tag` und `--replace-tag` (ersetzt `piko-neuheiten-2026` beim Re-Import).
- Lok-Autofix: Rh-Splits, `model.country`, PIKO `type`/`livery` (GTW, BR 440 bwegt, Talent 2, …).
- Enthält zudem DC-Analog-Korrektur für Gleichstrom ohne werkseitigen Decoder (vorheriger Branch-Stand).

## Test plan

- [ ] `npm run validate` / CI grün
- [ ] Stichprobe Artikel mit Tag `piko-neuheiten-2025` (z. B. `50739`, `21752`, `27506`)
- [ ] Optional: fehlende Nummern aus `.tmp/piko_2025_neuheiten_missing.txt` nachziehen mit `--campaign-tag piko-neuheiten-2025`


Made with [Cursor](https://cursor.com)